### PR TITLE
L2Migrator finalize migrate function logic

### DIFF
--- a/contracts/L1/gateway/L1Migrator.sol
+++ b/contracts/L1/gateway/L1Migrator.sol
@@ -304,6 +304,10 @@ contract L1Migrator is L1ArbitrumMessenger, IMigrator, EIP712 {
             total += amount;
         }
 
+        (, , address delegateAddress, , , , ) = bondingManager.getDelegator(
+            _l1Addr
+        );
+
         // We do not prevent migration replays here to minimize L1 gas costs
         // The L2Migrator is responsible for rejecting migration replays
 
@@ -312,7 +316,8 @@ contract L1Migrator is L1ArbitrumMessenger, IMigrator, EIP712 {
             l1Addr: _l1Addr,
             l2Addr: _l2Addr,
             total: total,
-            unbondingLockIds: _unbondingLockIds
+            unbondingLockIds: _unbondingLockIds,
+            delegate: delegateAddress
         });
 
         data = abi.encodeWithSelector(

--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -105,8 +105,11 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
             address poolAddr = Clones.clone(delegatorPoolImpl);
             delegatorPools[_params.l1Addr] = poolAddr;
 
-            // TODO: Subtract already claimed delegated stake
-            bondFor(_params.delegatedStake, poolAddr, _params.delegate);
+            bondFor(
+                _params.delegatedStake - claimedDelegatedStake[_params.l1Addr],
+                poolAddr,
+                _params.delegate
+            );
 
             emit DelegatorPoolCreated(_params.l1Addr, poolAddr);
         }

--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -26,6 +26,8 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
 
     mapping(address => bool) public migratedDelegators;
     mapping(address => address) public delegatorPools;
+    mapping(address => mapping(uint256 => bool)) public migratedUnbondingLocks;
+    mapping(address => bool) public migratedSenders;
 
     event MigrateDelegatorFinalized(MigrateDelegatorParams params);
 
@@ -82,7 +84,17 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
     function finalizeMigrateUnbondingLocks(
         MigrateUnbondingLocksParams memory _params
     ) external onlyL1Counterpart(l1Migrator) {
-        // TODO: Fill logic
+        for (uint256 i = 0; i < _params.unbondingLockIds.length; i++) {
+            uint256 id = _params.unbondingLockIds[i];
+            require(
+                !migratedUnbondingLocks[_params.l1Addr][id],
+                "L2Migrator#finalizeMigrateUnbondingLocks: ALREADY_MIGRATED"
+            );
+            migratedUnbondingLocks[_params.l1Addr][id] = true;
+        }
+
+        bondFor(_params.total, _params.l2Addr, _params.delegate);
+
         emit MigrateUnbondingLocksFinalized(_params);
     }
 

--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -73,7 +73,6 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
             !migratedDelegators[_params.l1Addr],
             "L2Migrator#finalizeMigrateDelegator: ALREADY_MIGRATED"
         );
-        // TODO: Check if claimed
 
         migratedDelegators[_params.l1Addr] = true;
 
@@ -87,6 +86,16 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
             bondFor(_params.delegatedStake, poolAddr, _params.delegate);
 
             emit DelegatorPoolCreated(_params.l1Addr, poolAddr);
+        }
+
+        // Use .call() since l2Addr could be a contract that needs more gas than
+        // the stipend provided by .transfer()
+        // TODO: Consider re-entrancy guard?
+        // All state updates occur before external calls in this function, but might be safer.
+        // Should consider what happens in the external calls if the next call re-enters this function.
+        if (_params.fees > 0) {
+            (bool ok, ) = _params.l2Addr.call{value: _params.fees}("");
+            require(ok, "L2Migrator#finalizeMigrateDelegator: FAIL_FEE");
         }
 
         emit MigrateDelegatorFinalized(_params);
@@ -128,6 +137,8 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
 
         emit MigrateSenderFinalized(_params);
     }
+
+    receive() external payable {}
 
     function bondFor(
         uint256 _amount,

--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -4,8 +4,28 @@ pragma solidity ^0.8.0;
 import {L2ArbitrumMessenger} from "./L2ArbitrumMessenger.sol";
 import {IMigrator} from "../../interfaces/IMigrator.sol";
 
+import "@openzeppelin/contracts/proxy/Clones.sol";
+
+interface IBondingManager {
+    function bondForWithHint(
+        uint256 _amount,
+        address _owner,
+        address _to,
+        address _oldDelegateNewPosPrev,
+        address _oldDelegateNewPosNext,
+        address _newDelegateNewPosPrev,
+        address _newDelegateNewPosNext
+    ) external;
+}
+
 contract L2Migrator is L2ArbitrumMessenger, IMigrator {
+    address public immutable bondingManagerAddr;
+
     address public l1Migrator;
+    address public delegatorPoolImpl;
+
+    mapping(address => bool) public migratedDelegators;
+    mapping(address => address) public delegatorPools;
 
     event MigrateDelegatorFinalized(MigrateDelegatorParams params);
 
@@ -13,8 +33,16 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
 
     event MigrateSenderFinalized(MigrateSenderParams params);
 
-    constructor(address _l1Migrator) {
+    event DelegatorPoolCreated(address indexed l1Addr, address delegatorPool);
+
+    constructor(
+        address _l1Migrator,
+        address _delegatorPoolImpl,
+        address _bondingManagerAddr
+    ) {
         l1Migrator = _l1Migrator;
+        delegatorPoolImpl = _delegatorPoolImpl;
+        bondingManagerAddr = _bondingManagerAddr;
     }
 
     // TODO: Add auth
@@ -22,11 +50,32 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
         l1Migrator = _l1Migrator;
     }
 
+    // TODO: Setter for delegatorPoolImpl?
+
     function finalizeMigrateDelegator(MigrateDelegatorParams memory _params)
         external
         onlyL1Counterpart(l1Migrator)
     {
-        // TODO: Fill logic
+        require(
+            !migratedDelegators[_params.l1Addr],
+            "L2Migrator#finalizeMigrateDelegator: ALREADY_MIGRATED"
+        );
+        // TODO: Check if claimed
+
+        migratedDelegators[_params.l1Addr] = true;
+
+        bondFor(_params.stake, _params.l2Addr, _params.delegate);
+
+        if (_params.l1Addr == _params.delegate) {
+            address poolAddr = Clones.clone(delegatorPoolImpl);
+            delegatorPools[_params.l1Addr] = poolAddr;
+
+            // TODO: Subtract already claimed delegated stake
+            bondFor(_params.delegatedStake, poolAddr, _params.delegate);
+
+            emit DelegatorPoolCreated(_params.l1Addr, poolAddr);
+        }
+
         emit MigrateDelegatorFinalized(_params);
     }
 
@@ -43,5 +92,23 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
     {
         // TODO: Fill logic
         emit MigrateSenderFinalized(_params);
+    }
+
+    function bondFor(
+        uint256 _amount,
+        address _owner,
+        address _to
+    ) internal {
+        IBondingManager bondingManager = IBondingManager(bondingManagerAddr);
+
+        bondingManager.bondForWithHint(
+            _amount,
+            _owner,
+            _to,
+            address(0),
+            address(0),
+            address(0),
+            address(0)
+        );
     }
 }

--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -90,9 +90,8 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
 
         // Use .call() since l2Addr could be a contract that needs more gas than
         // the stipend provided by .transfer()
-        // TODO: Consider re-entrancy guard?
-        // All state updates occur before external calls in this function, but might be safer.
-        // Should consider what happens in the external calls if the next call re-enters this function.
+        // The .call() is safe without a re-entrancy guard because this function cannot be re-entered
+        // by _params.l2Addr since the function can only be called by the L1Migrator via a cross-chain retryable ticket
         if (_params.fees > 0) {
             (bool ok, ) = _params.l2Addr.call{value: _params.fees}("");
             require(ok, "L2Migrator#finalizeMigrateDelegator: FAIL_FEE");

--- a/contracts/interfaces/IMigrator.sol
+++ b/contracts/interfaces/IMigrator.sol
@@ -28,6 +28,8 @@ interface IMigrator {
         uint256 total;
         // IDs of unbonding locks being migrated
         uint256[] unbondingLockIds;
+        // Delegate of l1Addr on L1
+        address delegate;
     }
 
     struct MigrateSenderParams {

--- a/test/unit/L1/l1Migrator.test.ts
+++ b/test/unit/L1/l1Migrator.test.ts
@@ -145,9 +145,12 @@ describe('L1Migrator', function() {
         },
     );
 
-    ticketBrokerMock = await smock.fake('ITicketBroker', {
-      address: mockTicketBrokerEOA.address,
-    });
+    ticketBrokerMock = await smock.fake(
+        'contracts/L1/gateway/L1Migrator.sol:ITicketBroker',
+        {
+          address: mockTicketBrokerEOA.address,
+        },
+    );
 
     inboxMock.bridge.returns(bridgeMock.address);
     bridgeMock.activeOutbox.returns(outboxMock.address);

--- a/test/unit/L1/l1Migrator.test.ts
+++ b/test/unit/L1/l1Migrator.test.ts
@@ -138,9 +138,12 @@ describe('L1Migrator', function() {
       address: mockBridgeEOA.address,
     });
 
-    bondingManagerMock = await smock.fake('IBondingManager', {
-      address: mockBondingManagerEOA.address,
-    });
+    bondingManagerMock = await smock.fake(
+        'contracts/L1/gateway/L1Migrator.sol:IBondingManager',
+        {
+          address: mockBondingManagerEOA.address,
+        },
+    );
 
     ticketBrokerMock = await smock.fake('ITicketBroker', {
       address: mockTicketBrokerEOA.address,

--- a/test/unit/L1/l1Migrator.test.ts
+++ b/test/unit/L1/l1Migrator.test.ts
@@ -414,6 +414,7 @@ describe('L1Migrator', function() {
       const unbondingLockIds = [1, 2];
       const lock1Amount = 100;
       const lock2Amount = 200;
+      const delegate = notL1EOA.address;
 
       inboxMock.createRetryableTicket.returns(seqNo);
       bondingManagerMock.getDelegatorUnbondingLock
@@ -422,6 +423,7 @@ describe('L1Migrator', function() {
       bondingManagerMock.getDelegatorUnbondingLock
           .whenCalledWith(l1EOA.address, 2)
           .returns([lock2Amount, 0]);
+      bondingManagerMock.getDelegator.returns([0, 0, delegate, 0, 0, 0, 0]);
 
       const maxGas = 111;
       const gasPriceBid = 222;
@@ -433,6 +435,7 @@ describe('L1Migrator', function() {
         l2Addr: l1EOA.address,
         total: lock1Amount + lock2Amount,
         unbondingLockIds,
+        delegate,
       };
       const l2Calldata =
         IL2Migrator__factory.createInterface().encodeFunctionData(

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -146,10 +146,12 @@ describe('L2Migrator', function() {
         fees: 300,
       };
 
-      const tx = l2Migrator.connect(mockL1MigratorL2AliasEOA).finalizeMigrateDelegator(
-          params,
+      const tx = l2Migrator
+          .connect(mockL1MigratorL2AliasEOA)
+          .finalizeMigrateDelegator(params);
+      await expect(tx).to.revertedWith(
+          'L2Migrator#finalizeMigrateDelegator: FAIL_FEE',
       );
-      await expect(tx).to.revertedWith('L2Migrator#finalizeMigrateDelegator: FAIL_FEE');
     });
 
     describe('finalizes migration', () => {
@@ -248,9 +250,9 @@ describe('L2Migrator', function() {
           value: ethers.utils.parseUnits('1', 'ether'),
         });
 
-        const tx = await l2Migrator.connect(mockL1MigratorL2AliasEOA).finalizeMigrateDelegator(
-            params,
-        );
+        const tx = await l2Migrator
+            .connect(mockL1MigratorL2AliasEOA)
+            .finalizeMigrateDelegator(params);
         await expect(tx).to.changeEtherBalance(l2AddrEOA, params.fees);
       });
     });

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -247,13 +247,12 @@ describe('L2Migrator', function() {
       });
 
       it('subtracted claimed delegated stake when staking for delegator pool', async () => {
-        const delegator = l2AddrEOA.address;
+        const delegator = l2AddrEOA;
         const delegate = l1AddrEOA.address;
         const stake = 50;
         const fees = 0;
 
-        await l2Migrator.connect(l2AddrEOA).claimStake(
-            delegator,
+        await l2Migrator.connect(delegator).claimStake(
             delegate,
             stake,
             fees,
@@ -462,7 +461,6 @@ describe('L2Migrator', function() {
 
       const tx = l2Migrator.connect(l1AddrEOA).claimStake(
           ethers.constants.AddressZero,
-          ethers.constants.AddressZero,
           0,
           0,
           [],
@@ -473,7 +471,6 @@ describe('L2Migrator', function() {
 
     it('reverts if delegator is already migrated', async () => {
       await l2Migrator.connect(l1AddrEOA).claimStake(
-          l1AddrEOA.address,
           l2AddrEOA.address,
           100,
           0,
@@ -482,7 +479,6 @@ describe('L2Migrator', function() {
       );
 
       const tx = l2Migrator.connect(l1AddrEOA).claimStake(
-          l1AddrEOA.address,
           l2AddrEOA.address,
           100,
           0,
@@ -494,7 +490,6 @@ describe('L2Migrator', function() {
 
     it('reverts if fee transfer fails', async () => {
       const tx = l2Migrator.connect(l1AddrEOA).claimStake(
-          l1AddrEOA.address,
           l2AddrEOA.address,
           100,
           200,
@@ -520,15 +515,14 @@ describe('L2Migrator', function() {
           address: delegatorPoolAddr,
         });
 
-        const delegator = l2AddrEOA.address;
+        const delegator = l2AddrEOA;
         const delegate = l1AddrEOA.address;
         const stake = 100;
         const fees = 0;
 
         expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(0);
 
-        const tx = await l2Migrator.connect(l2AddrEOA).claimStake(
-            delegator,
+        const tx = await l2Migrator.connect(delegator).claimStake(
             delegate,
             stake,
             fees,
@@ -536,17 +530,17 @@ describe('L2Migrator', function() {
             ethers.constants.AddressZero,
         );
 
-        expect(await l2Migrator.migratedDelegators(delegator)).to.be.true;
+        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be.true;
         expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(stake);
         expect(delegatorPoolMock.claim).to.be.calledOnceWith(l2AddrEOA.address, 100);
 
         await expect(tx)
             .to.emit(l2Migrator, 'StakeClaimed')
-            .withArgs(delegator, delegate, stake, fees);
+            .withArgs(delegator.address, delegate, stake, fees);
       });
 
       it('stakes in BondingManager if delegator pool does not exist', async () => {
-        const delegator = l1AddrEOA.address;
+        const delegator = l1AddrEOA;
         const delegate = l2AddrEOA.address;
         const stake = 100;
         const fees = 0;
@@ -554,8 +548,7 @@ describe('L2Migrator', function() {
         expect(await l2Migrator.delegatorPools(delegate)).to.be.equal(ethers.constants.AddressZero);
         expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(0);
 
-        const tx = await l2Migrator.connect(l1AddrEOA).claimStake(
-            delegator,
+        const tx = await l2Migrator.connect(delegator).claimStake(
             delegate,
             stake,
             fees,
@@ -563,11 +556,11 @@ describe('L2Migrator', function() {
             ethers.constants.AddressZero,
         );
 
-        expect(await l2Migrator.migratedDelegators(delegator)).to.be.true;
+        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be.true;
         expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(stake);
         expect(bondingManagerMock.bondForWithHint).to.be.calledOnceWith(
             stake,
-            delegator,
+            delegator.address,
             delegate,
             ethers.constants.AddressZero,
             ethers.constants.AddressZero,
@@ -577,18 +570,17 @@ describe('L2Migrator', function() {
 
         await expect(tx)
             .to.emit(l2Migrator, 'StakeClaimed')
-            .withArgs(delegator, delegate, stake, fees);
+            .withArgs(delegator.address, delegate, stake, fees);
       });
 
       it('stakes in BondingManager with specified new delegate', async () => {
-        const delegator = l1AddrEOA.address;
+        const delegator = l1AddrEOA;
         const delegate = l2AddrEOA.address;
         const stake = 100;
         const fees = 0;
         const newDelegate = l2Migrator.address;
 
-        const tx = await l2Migrator.connect(l1AddrEOA).claimStake(
-            delegator,
+        const tx = await l2Migrator.connect(delegator).claimStake(
             delegate,
             stake,
             fees,
@@ -598,7 +590,7 @@ describe('L2Migrator', function() {
 
         expect(bondingManagerMock.bondForWithHint).to.be.calledOnceWith(
             stake,
-            delegator,
+            delegator.address,
             newDelegate,
             ethers.constants.AddressZero,
             ethers.constants.AddressZero,
@@ -608,11 +600,11 @@ describe('L2Migrator', function() {
 
         await expect(tx)
             .to.emit(l2Migrator, 'StakeClaimed')
-            .withArgs(delegator, newDelegate, stake, fees);
+            .withArgs(delegator.address, newDelegate, stake, fees);
       });
 
       it('transfers if fees > 0', async () => {
-        const delegator = l1AddrEOA.address;
+        const delegator = l1AddrEOA;
         const delegate = l2AddrEOA.address;
         const stake = 100;
         const fees = 200;
@@ -622,8 +614,7 @@ describe('L2Migrator', function() {
           value: ethers.utils.parseUnits('1', 'ether'),
         });
 
-        const tx = await l2Migrator.connect(l1AddrEOA).claimStake(
-            delegator,
+        const tx = await l2Migrator.connect(delegator).claimStake(
             delegate,
             stake,
             fees,
@@ -631,7 +622,7 @@ describe('L2Migrator', function() {
             ethers.constants.AddressZero,
         );
 
-        await expect(tx).to.changeEtherBalance(l1AddrEOA, fees);
+        await expect(tx).to.changeEtherBalance(delegator, fees);
       });
     });
   });

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -1,28 +1,36 @@
+import {FakeContract, smock} from '@defi-wonderland/smock';
 import {Signer} from '@ethersproject/abstract-signer';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/dist/src/signers';
-import {expect} from 'chai';
+import {expect, use} from 'chai';
 
 import {ethers} from 'hardhat';
 import {L2Migrator, L2Migrator__factory} from '../../../typechain';
 import {getL2SignerFromL1} from '../../utils/messaging';
 
+use(smock.matchers);
+
 describe('L2Migrator', function() {
   let l2Migrator: L2Migrator;
 
   let notL1MigratorEOA: SignerWithAddress;
+  let l1AddrEOA: SignerWithAddress;
+  let l2AddrEOA: SignerWithAddress;
 
   // mocks
+  let bondingManagerMock: FakeContract;
   let mockL1MigratorEOA: SignerWithAddress;
   let mockL1MigratorL2AliasEOA: Signer;
+  let mockDelegatorPoolEOA: SignerWithAddress;
+  let mockBondingManagerEOA: SignerWithAddress;
 
-  const mockMigrateDelegatorParams = {
+  const mockMigrateDelegatorParams = () => ({
     l1Addr: ethers.constants.AddressZero,
     l2Addr: ethers.constants.AddressZero,
     stake: 100,
     delegatedStake: 200,
     fees: 300,
     delegate: ethers.constants.AddressZero,
-  };
+  });
 
   const mockMigrateUnbondingLocksParams = {
     l1Addr: ethers.constants.AddressZero,
@@ -39,13 +47,31 @@ describe('L2Migrator', function() {
   };
 
   beforeEach(async function() {
-    [notL1MigratorEOA, mockL1MigratorEOA] = await ethers.getSigners();
+    [
+      notL1MigratorEOA,
+      l1AddrEOA,
+      l2AddrEOA,
+      mockL1MigratorEOA,
+      mockDelegatorPoolEOA,
+      mockBondingManagerEOA,
+    ] = await ethers.getSigners();
 
     const L2Migrator: L2Migrator__factory = await ethers.getContractFactory(
         'L2Migrator',
     );
-    l2Migrator = await L2Migrator.deploy(mockL1MigratorEOA.address);
+    l2Migrator = await L2Migrator.deploy(
+        mockL1MigratorEOA.address,
+        mockDelegatorPoolEOA.address,
+        mockBondingManagerEOA.address,
+    );
     await l2Migrator.deployed();
+
+    bondingManagerMock = await smock.fake(
+        'contracts/L2/gateway/L2Migrator.sol:IBondingManager',
+        {
+          address: mockBondingManagerEOA.address,
+        },
+    );
 
     // TODO: Modify getL2SignerFromL1 to return Promise<SignerWithAddress> instead of
     // Promise<Signer>?
@@ -60,6 +86,10 @@ describe('L2Migrator', function() {
     it('sets addresses', async () => {
       const l1MigratorAddr = await l2Migrator.l1Migrator();
       expect(l1MigratorAddr).to.equal(mockL1MigratorEOA.address);
+      const delegatorPoolImpl = await l2Migrator.delegatorPoolImpl();
+      expect(delegatorPoolImpl).to.equal(mockDelegatorPoolEOA.address);
+      const bondingManagerAddr = await l2Migrator.bondingManagerAddr();
+      expect(bondingManagerAddr).to.equal(mockBondingManagerEOA.address);
     });
   });
 
@@ -76,24 +106,106 @@ describe('L2Migrator', function() {
       // msg.sender = some invalid address
       let tx = l2Migrator
           .connect(notL1MigratorEOA)
-          .finalizeMigrateDelegator(mockMigrateDelegatorParams);
+          .finalizeMigrateDelegator(mockMigrateDelegatorParams());
       await expect(tx).to.revertedWith('ONLY_COUNTERPART_GATEWAY');
 
       // msg.sender = L1Migrator (no alias)
       tx = l2Migrator
           .connect(mockL1MigratorEOA)
-          .finalizeMigrateDelegator(mockMigrateDelegatorParams);
+          .finalizeMigrateDelegator(mockMigrateDelegatorParams());
       await expect(tx).to.revertedWith('ONLY_COUNTERPART_GATEWAY');
     });
 
-    it('finalizes migration', async () => {
+    it('reverts when l1Addr already migrated', async () => {
+      await l2Migrator
+          .connect(mockL1MigratorL2AliasEOA)
+          .finalizeMigrateDelegator(mockMigrateDelegatorParams());
+
       const tx = l2Migrator
           .connect(mockL1MigratorL2AliasEOA)
-          .finalizeMigrateDelegator(mockMigrateDelegatorParams);
+          .finalizeMigrateDelegator(mockMigrateDelegatorParams());
+      await expect(tx).to.revertedWith(
+          'L2Migrator#finalizeMigrateDelegator: ALREADY_MIGRATED',
+      );
+    });
 
-      await expect(tx).to.emit(l2Migrator, 'MigrateDelegatorFinalized');
-      // The assertion below does not work until https://github.com/EthWorks/Waffle/issues/245 is fixed
-      // .withArgs(seqNo, mockMigrateDelegatorParams)
+    describe('finalizes migration', () => {
+      it('no delegator pool if l1Addr != delegate', async () => {
+        const params = mockMigrateDelegatorParams();
+        params.l1Addr = l1AddrEOA.address;
+        params.l2Addr = l2AddrEOA.address;
+        params.delegate = l2AddrEOA.address;
+
+        const tx = await l2Migrator
+            .connect(mockL1MigratorL2AliasEOA)
+            .finalizeMigrateDelegator(params);
+
+        expect(await l2Migrator.migratedDelegators(params.l1Addr)).to.be.true;
+
+        expect(await l2Migrator.delegatorPools(params.l1Addr)).to.be.equal(
+            ethers.constants.AddressZero,
+        );
+
+        expect(bondingManagerMock.bondForWithHint).to.be.calledOnceWith(
+            params.stake,
+            params.l2Addr,
+            params.delegate,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+        );
+
+        await expect(tx).to.not.emit(l2Migrator, 'DelegatorPoolCreated');
+
+        await expect(tx).to.emit(l2Migrator, 'MigrateDelegatorFinalized');
+        // The assertion below does not work until https://github.com/EthWorks/Waffle/issues/245 is fixed
+        // .withArgs(seqNo, params)
+      });
+
+      it('creates delegator pool if l1Addr == delegate', async () => {
+        const params = mockMigrateDelegatorParams();
+        params.l1Addr = l1AddrEOA.address;
+        params.l2Addr = l2AddrEOA.address;
+        params.delegate = l1AddrEOA.address;
+
+        const tx = await l2Migrator
+            .connect(mockL1MigratorL2AliasEOA)
+            .finalizeMigrateDelegator(params);
+
+        expect(await l2Migrator.migratedDelegators(params.l1Addr)).to.be.true;
+
+        const delegatorPool = await l2Migrator.delegatorPools(params.l1Addr);
+        expect(delegatorPool).to.not.be.equal(ethers.constants.AddressZero);
+
+        expect(bondingManagerMock.bondForWithHint.atCall(0)).to.be.calledWith(
+            params.stake,
+            params.l2Addr,
+            params.delegate,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+        );
+
+        expect(bondingManagerMock.bondForWithHint.atCall(1)).to.be.calledWith(
+            params.delegatedStake,
+            delegatorPool,
+            params.delegate,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+        );
+
+        await expect(tx)
+            .to.emit(l2Migrator, 'DelegatorPoolCreated')
+            .withArgs(params.l1Addr, delegatorPool);
+
+        await expect(tx).to.emit(l2Migrator, 'MigrateDelegatorFinalized');
+        // The assertion below does not work until https://github.com/EthWorks/Waffle/issues/245 is fixed
+        // .withArgs(seqNo, params)
+      });
     });
   });
 

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -1,5 +1,4 @@
 import {FakeContract, smock} from '@defi-wonderland/smock';
-import {Signer} from '@ethersproject/abstract-signer';
 import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/dist/src/signers';
 import {expect, use} from 'chai';
 
@@ -20,7 +19,7 @@ describe('L2Migrator', function() {
   let bondingManagerMock: FakeContract;
   let ticketBrokerMock: FakeContract;
   let mockL1MigratorEOA: SignerWithAddress;
-  let mockL1MigratorL2AliasEOA: Signer;
+  let mockL1MigratorL2AliasEOA: SignerWithAddress;
   let mockDelegatorPoolEOA: SignerWithAddress;
   let mockBondingManagerEOA: SignerWithAddress;
   let mockTicketBrokerEOA: SignerWithAddress;
@@ -85,11 +84,9 @@ describe('L2Migrator', function() {
         },
     );
 
-    // TODO: Modify getL2SignerFromL1 to return Promise<SignerWithAddress> instead of
-    // Promise<Signer>?
     mockL1MigratorL2AliasEOA = await getL2SignerFromL1(mockL1MigratorEOA);
     await mockL1MigratorEOA.sendTransaction({
-      to: await mockL1MigratorL2AliasEOA.getAddress(),
+      to: mockL1MigratorL2AliasEOA.address,
       value: ethers.utils.parseUnits('1', 'ether'),
     });
   });

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -141,8 +141,10 @@ describe('L2Migrator', function() {
     });
 
     it('reverts if fee transfer fails', async () => {
-      const params = mockMigrateDelegatorParams();
-      params.fees = 300;
+      const params = {
+        ...mockMigrateDelegatorParams(),
+        fees: 300,
+      };
 
       const tx = l2Migrator.connect(mockL1MigratorL2AliasEOA).finalizeMigrateDelegator(
           params,
@@ -152,10 +154,12 @@ describe('L2Migrator', function() {
 
     describe('finalizes migration', () => {
       it('no delegator pool if l1Addr != delegate', async () => {
-        const params = mockMigrateDelegatorParams();
-        params.l1Addr = l1AddrEOA.address;
-        params.l2Addr = l2AddrEOA.address;
-        params.delegate = l2AddrEOA.address;
+        const params = {
+          ...mockMigrateDelegatorParams(),
+          l1Addr: l1AddrEOA.address,
+          l2Addr: l2AddrEOA.address,
+          delegate: l2AddrEOA.address,
+        };
 
         const tx = await l2Migrator
             .connect(mockL1MigratorL2AliasEOA)
@@ -185,10 +189,12 @@ describe('L2Migrator', function() {
       });
 
       it('creates delegator pool if l1Addr == delegate', async () => {
-        const params = mockMigrateDelegatorParams();
-        params.l1Addr = l1AddrEOA.address;
-        params.l2Addr = l2AddrEOA.address;
-        params.delegate = l1AddrEOA.address;
+        const params = {
+          ...mockMigrateDelegatorParams(),
+          l1Addr: l1AddrEOA.address,
+          l2Addr: l2AddrEOA.address,
+          delegate: l1AddrEOA.address,
+        };
 
         const tx = await l2Migrator
             .connect(mockL1MigratorL2AliasEOA)
@@ -229,11 +235,13 @@ describe('L2Migrator', function() {
       });
 
       it('transfers fees if > 0', async () => {
-        const params = mockMigrateDelegatorParams();
-        params.l1Addr = l1AddrEOA.address;
-        params.l2Addr = l2AddrEOA.address;
-        params.delegate = l2AddrEOA.address;
-        params.fees = 300;
+        const params = {
+          ...mockMigrateDelegatorParams(),
+          l1Addr: l1AddrEOA.address,
+          l2Addr: l2AddrEOA.address,
+          delegate: l2AddrEOA.address,
+          fees: 300,
+        };
 
         await mockL1MigratorEOA.sendTransaction({
           to: l2Migrator.address,
@@ -360,9 +368,11 @@ describe('L2Migrator', function() {
     });
 
     it('finalizes migration', async () => {
-      const params = mockMigrateSenderParams();
-      params.l1Addr = l1AddrEOA.address;
-      params.l2Addr = l2AddrEOA.address;
+      const params = {
+        ...mockMigrateSenderParams(),
+        l1Addr: l1AddrEOA.address,
+        l2Addr: l2AddrEOA.address,
+      };
 
       const tx = await l2Migrator
           .connect(mockL1MigratorL2AliasEOA)

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -252,15 +252,13 @@ describe('L2Migrator', function() {
         const stake = 50;
         const fees = 0;
 
-        await l2Migrator.connect(delegator).claimStake(
-            delegate,
-            stake,
-            fees,
-            [],
-            ethers.constants.AddressZero,
-        );
+        await l2Migrator
+            .connect(delegator)
+            .claimStake(delegate, stake, fees, [], ethers.constants.AddressZero);
 
-        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(stake);
+        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(
+            stake,
+        );
 
         const params = mockMigrateDelegatorParams();
         params.l1Addr = delegate;
@@ -269,9 +267,9 @@ describe('L2Migrator', function() {
 
         bondingManagerMock.bondForWithHint.reset();
 
-        await l2Migrator.connect(mockL1MigratorL2AliasEOA).finalizeMigrateDelegator(
-            params,
-        );
+        await l2Migrator
+            .connect(mockL1MigratorL2AliasEOA)
+            .finalizeMigrateDelegator(params);
 
         const delegatorPool = await l2Migrator.delegatorPools(params.l1Addr);
         expect(bondingManagerMock.bondForWithHint.atCall(1)).to.be.calledWith(
@@ -459,43 +457,51 @@ describe('L2Migrator', function() {
     it('reverts for invalid proof', async () => {
       merkleSnapshotMock.verify.returns(false);
 
-      const tx = l2Migrator.connect(l1AddrEOA).claimStake(
-          ethers.constants.AddressZero,
-          0,
-          0,
-          [],
-          ethers.constants.AddressZero,
-      );
+      const tx = l2Migrator
+          .connect(l1AddrEOA)
+          .claimStake(
+              ethers.constants.AddressZero,
+              0,
+              0,
+              [],
+              ethers.constants.AddressZero,
+          );
       await expect(tx).to.revertedWith('L2Migrator#claimStake: INVALID_PROOF');
     });
 
     it('reverts if delegator is already migrated', async () => {
-      await l2Migrator.connect(l1AddrEOA).claimStake(
-          l2AddrEOA.address,
-          100,
-          0,
-          [],
-          ethers.constants.AddressZero,
-      );
+      await l2Migrator
+          .connect(l1AddrEOA)
+          .claimStake(
+              l2AddrEOA.address,
+              100,
+              0,
+              [],
+              ethers.constants.AddressZero,
+          );
 
-      const tx = l2Migrator.connect(l1AddrEOA).claimStake(
-          l2AddrEOA.address,
-          100,
-          0,
-          [],
-          ethers.constants.AddressZero,
-      );
+      const tx = l2Migrator
+          .connect(l1AddrEOA)
+          .claimStake(
+              l2AddrEOA.address,
+              100,
+              0,
+              [],
+              ethers.constants.AddressZero,
+          );
       expect(tx).to.revertedWith('L2Migrator#claimStake: ALREADY_MIGRATED');
     });
 
     it('reverts if fee transfer fails', async () => {
-      const tx = l2Migrator.connect(l1AddrEOA).claimStake(
-          l2AddrEOA.address,
-          100,
-          200,
-          [],
-          ethers.constants.AddressZero,
-      );
+      const tx = l2Migrator
+          .connect(l1AddrEOA)
+          .claimStake(
+              l2AddrEOA.address,
+              100,
+              200,
+              [],
+              ethers.constants.AddressZero,
+          );
       expect(tx).to.be.reverted;
     });
 
@@ -506,14 +512,21 @@ describe('L2Migrator', function() {
         params.l2Addr = l1AddrEOA.address;
         params.delegate = l1AddrEOA.address;
 
-        await l2Migrator.connect(mockL1MigratorL2AliasEOA).finalizeMigrateDelegator(params);
+        await l2Migrator
+            .connect(mockL1MigratorL2AliasEOA)
+            .finalizeMigrateDelegator(params);
 
-        const delegatorPoolAddr = await l2Migrator.delegatorPools(params.l1Addr);
+        const delegatorPoolAddr = await l2Migrator.delegatorPools(
+            params.l1Addr,
+        );
         expect(delegatorPoolAddr).to.not.be.equal(ethers.constants.AddressZero);
 
-        const delegatorPoolMock: FakeContract = await smock.fake('IDelegatorPool', {
-          address: delegatorPoolAddr,
-        });
+        const delegatorPoolMock: FakeContract = await smock.fake(
+            'IDelegatorPool',
+            {
+              address: delegatorPoolAddr,
+            },
+        );
 
         const delegator = l2AddrEOA;
         const delegate = l1AddrEOA.address;
@@ -522,17 +535,19 @@ describe('L2Migrator', function() {
 
         expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(0);
 
-        const tx = await l2Migrator.connect(delegator).claimStake(
-            delegate,
-            stake,
-            fees,
-            [],
-            ethers.constants.AddressZero,
-        );
+        const tx = await l2Migrator
+            .connect(delegator)
+            .claimStake(delegate, stake, fees, [], ethers.constants.AddressZero);
 
-        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be.true;
-        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(stake);
-        expect(delegatorPoolMock.claim).to.be.calledOnceWith(l2AddrEOA.address, 100);
+        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be
+            .true;
+        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(
+            stake,
+        );
+        expect(delegatorPoolMock.claim).to.be.calledOnceWith(
+            l2AddrEOA.address,
+            100,
+        );
 
         await expect(tx)
             .to.emit(l2Migrator, 'StakeClaimed')
@@ -545,19 +560,20 @@ describe('L2Migrator', function() {
         const stake = 100;
         const fees = 0;
 
-        expect(await l2Migrator.delegatorPools(delegate)).to.be.equal(ethers.constants.AddressZero);
-        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(0);
-
-        const tx = await l2Migrator.connect(delegator).claimStake(
-            delegate,
-            stake,
-            fees,
-            [],
+        expect(await l2Migrator.delegatorPools(delegate)).to.be.equal(
             ethers.constants.AddressZero,
         );
+        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(0);
 
-        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be.true;
-        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(stake);
+        const tx = await l2Migrator
+            .connect(delegator)
+            .claimStake(delegate, stake, fees, [], ethers.constants.AddressZero);
+
+        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be
+            .true;
+        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(
+            stake,
+        );
         expect(bondingManagerMock.bondForWithHint).to.be.calledOnceWith(
             stake,
             delegator.address,
@@ -580,13 +596,9 @@ describe('L2Migrator', function() {
         const fees = 0;
         const newDelegate = l2Migrator.address;
 
-        const tx = await l2Migrator.connect(delegator).claimStake(
-            delegate,
-            stake,
-            fees,
-            [],
-            newDelegate,
-        );
+        const tx = await l2Migrator
+            .connect(delegator)
+            .claimStake(delegate, stake, fees, [], newDelegate);
 
         expect(bondingManagerMock.bondForWithHint).to.be.calledOnceWith(
             stake,
@@ -614,13 +626,9 @@ describe('L2Migrator', function() {
           value: ethers.utils.parseUnits('1', 'ether'),
         });
 
-        const tx = await l2Migrator.connect(delegator).claimStake(
-            delegate,
-            stake,
-            fees,
-            [],
-            ethers.constants.AddressZero,
-        );
+        const tx = await l2Migrator
+            .connect(delegator)
+            .claimStake(delegate, stake, fees, [], ethers.constants.AddressZero);
 
         await expect(tx).to.changeEtherBalance(delegator, fees);
       });


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Adds logic for finalize migrate functions in the L2Migrator.

Also, updated the `MigrateUnbondingLocksParams` passed by the L1Migrator to the `finalizeMigrateUnbondingLocks()` call to include the delegator's delegate address from L1. The staking behavior of `finalizeMigrateUnbondingLocks()` is now aligned with the staking behavior of `finalizeMigrateDelegator()` - stake will be delegated to the delegate from L1 and the delegator can always re-delegate on L2 moving forward.

Also, added a payable `receive()` function to the L2Migrator so that it can accept ETH. This is currently used for tests, but this can also enable the L2Migrator to receive ETH that is bridged from L1 as a part of the solution for livepeer/protocol#493.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Partially fixes livepeer/protocol#489.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
