### PR TITLE
L2Migrator claim stake using snapshot

### DIFF
--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -105,8 +105,11 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
             address poolAddr = Clones.clone(delegatorPoolImpl);
             delegatorPools[_params.l1Addr] = poolAddr;
 
-            // TODO: Subtract already claimed delegated stake
-            bondFor(_params.delegatedStake, poolAddr, _params.delegate);
+            bondFor(
+                _params.delegatedStake - claimedDelegatedStake[_params.l1Addr],
+                poolAddr,
+                _params.delegate
+            );
 
             emit DelegatorPoolCreated(_params.l1Addr, poolAddr);
         }

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -247,13 +247,12 @@ describe('L2Migrator', function() {
       });
 
       it('subtracted claimed delegated stake when staking for delegator pool', async () => {
-        const delegator = l2AddrEOA.address;
+        const delegator = l2AddrEOA;
         const delegate = l1AddrEOA.address;
         const stake = 50;
         const fees = 0;
 
-        await l2Migrator.connect(l2AddrEOA).claimStake(
-            delegator,
+        await l2Migrator.connect(delegator).claimStake(
             delegate,
             stake,
             fees,
@@ -462,7 +461,6 @@ describe('L2Migrator', function() {
 
       const tx = l2Migrator.connect(l1AddrEOA).claimStake(
           ethers.constants.AddressZero,
-          ethers.constants.AddressZero,
           0,
           0,
           [],
@@ -473,7 +471,6 @@ describe('L2Migrator', function() {
 
     it('reverts if delegator is already migrated', async () => {
       await l2Migrator.connect(l1AddrEOA).claimStake(
-          l1AddrEOA.address,
           l2AddrEOA.address,
           100,
           0,
@@ -482,7 +479,6 @@ describe('L2Migrator', function() {
       );
 
       const tx = l2Migrator.connect(l1AddrEOA).claimStake(
-          l1AddrEOA.address,
           l2AddrEOA.address,
           100,
           0,
@@ -494,7 +490,6 @@ describe('L2Migrator', function() {
 
     it('reverts if fee transfer fails', async () => {
       const tx = l2Migrator.connect(l1AddrEOA).claimStake(
-          l1AddrEOA.address,
           l2AddrEOA.address,
           100,
           200,
@@ -520,15 +515,14 @@ describe('L2Migrator', function() {
           address: delegatorPoolAddr,
         });
 
-        const delegator = l2AddrEOA.address;
+        const delegator = l2AddrEOA;
         const delegate = l1AddrEOA.address;
         const stake = 100;
         const fees = 0;
 
         expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(0);
 
-        const tx = await l2Migrator.connect(l2AddrEOA).claimStake(
-            delegator,
+        const tx = await l2Migrator.connect(delegator).claimStake(
             delegate,
             stake,
             fees,
@@ -536,17 +530,17 @@ describe('L2Migrator', function() {
             ethers.constants.AddressZero,
         );
 
-        expect(await l2Migrator.migratedDelegators(delegator)).to.be.true;
+        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be.true;
         expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(stake);
         expect(delegatorPoolMock.claim).to.be.calledOnceWith(l2AddrEOA.address, 100);
 
         await expect(tx)
             .to.emit(l2Migrator, 'StakeClaimed')
-            .withArgs(delegator, delegate, stake, fees);
+            .withArgs(delegator.address, delegate, stake, fees);
       });
 
       it('stakes in BondingManager if delegator pool does not exist', async () => {
-        const delegator = l1AddrEOA.address;
+        const delegator = l1AddrEOA;
         const delegate = l2AddrEOA.address;
         const stake = 100;
         const fees = 0;
@@ -554,8 +548,7 @@ describe('L2Migrator', function() {
         expect(await l2Migrator.delegatorPools(delegate)).to.be.equal(ethers.constants.AddressZero);
         expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(0);
 
-        const tx = await l2Migrator.connect(l1AddrEOA).claimStake(
-            delegator,
+        const tx = await l2Migrator.connect(delegator).claimStake(
             delegate,
             stake,
             fees,
@@ -563,11 +556,11 @@ describe('L2Migrator', function() {
             ethers.constants.AddressZero,
         );
 
-        expect(await l2Migrator.migratedDelegators(delegator)).to.be.true;
+        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be.true;
         expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(stake);
         expect(bondingManagerMock.bondForWithHint).to.be.calledOnceWith(
             stake,
-            delegator,
+            delegator.address,
             delegate,
             ethers.constants.AddressZero,
             ethers.constants.AddressZero,
@@ -577,18 +570,17 @@ describe('L2Migrator', function() {
 
         await expect(tx)
             .to.emit(l2Migrator, 'StakeClaimed')
-            .withArgs(delegator, delegate, stake, fees);
+            .withArgs(delegator.address, delegate, stake, fees);
       });
 
       it('stakes in BondingManager with specified new delegate', async () => {
-        const delegator = l1AddrEOA.address;
+        const delegator = l1AddrEOA;
         const delegate = l2AddrEOA.address;
         const stake = 100;
         const fees = 0;
         const newDelegate = l2Migrator.address;
 
-        const tx = await l2Migrator.connect(l1AddrEOA).claimStake(
-            delegator,
+        const tx = await l2Migrator.connect(delegator).claimStake(
             delegate,
             stake,
             fees,
@@ -598,7 +590,7 @@ describe('L2Migrator', function() {
 
         expect(bondingManagerMock.bondForWithHint).to.be.calledOnceWith(
             stake,
-            delegator,
+            delegator.address,
             newDelegate,
             ethers.constants.AddressZero,
             ethers.constants.AddressZero,
@@ -608,11 +600,11 @@ describe('L2Migrator', function() {
 
         await expect(tx)
             .to.emit(l2Migrator, 'StakeClaimed')
-            .withArgs(delegator, newDelegate, stake, fees);
+            .withArgs(delegator.address, newDelegate, stake, fees);
       });
 
       it('transfers if fees > 0', async () => {
-        const delegator = l1AddrEOA.address;
+        const delegator = l1AddrEOA;
         const delegate = l2AddrEOA.address;
         const stake = 100;
         const fees = 200;
@@ -622,8 +614,7 @@ describe('L2Migrator', function() {
           value: ethers.utils.parseUnits('1', 'ether'),
         });
 
-        const tx = await l2Migrator.connect(l1AddrEOA).claimStake(
-            delegator,
+        const tx = await l2Migrator.connect(delegator).claimStake(
             delegate,
             stake,
             fees,
@@ -631,7 +622,7 @@ describe('L2Migrator', function() {
             ethers.constants.AddressZero,
         );
 
-        await expect(tx).to.changeEtherBalance(l1AddrEOA, fees);
+        await expect(tx).to.changeEtherBalance(delegator, fees);
       });
     });
   });

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -252,15 +252,13 @@ describe('L2Migrator', function() {
         const stake = 50;
         const fees = 0;
 
-        await l2Migrator.connect(delegator).claimStake(
-            delegate,
-            stake,
-            fees,
-            [],
-            ethers.constants.AddressZero,
-        );
+        await l2Migrator
+            .connect(delegator)
+            .claimStake(delegate, stake, fees, [], ethers.constants.AddressZero);
 
-        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(stake);
+        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(
+            stake,
+        );
 
         const params = mockMigrateDelegatorParams();
         params.l1Addr = delegate;
@@ -269,9 +267,9 @@ describe('L2Migrator', function() {
 
         bondingManagerMock.bondForWithHint.reset();
 
-        await l2Migrator.connect(mockL1MigratorL2AliasEOA).finalizeMigrateDelegator(
-            params,
-        );
+        await l2Migrator
+            .connect(mockL1MigratorL2AliasEOA)
+            .finalizeMigrateDelegator(params);
 
         const delegatorPool = await l2Migrator.delegatorPools(params.l1Addr);
         expect(bondingManagerMock.bondForWithHint.atCall(1)).to.be.calledWith(
@@ -459,43 +457,51 @@ describe('L2Migrator', function() {
     it('reverts for invalid proof', async () => {
       merkleSnapshotMock.verify.returns(false);
 
-      const tx = l2Migrator.connect(l1AddrEOA).claimStake(
-          ethers.constants.AddressZero,
-          0,
-          0,
-          [],
-          ethers.constants.AddressZero,
-      );
+      const tx = l2Migrator
+          .connect(l1AddrEOA)
+          .claimStake(
+              ethers.constants.AddressZero,
+              0,
+              0,
+              [],
+              ethers.constants.AddressZero,
+          );
       await expect(tx).to.revertedWith('L2Migrator#claimStake: INVALID_PROOF');
     });
 
     it('reverts if delegator is already migrated', async () => {
-      await l2Migrator.connect(l1AddrEOA).claimStake(
-          l2AddrEOA.address,
-          100,
-          0,
-          [],
-          ethers.constants.AddressZero,
-      );
+      await l2Migrator
+          .connect(l1AddrEOA)
+          .claimStake(
+              l2AddrEOA.address,
+              100,
+              0,
+              [],
+              ethers.constants.AddressZero,
+          );
 
-      const tx = l2Migrator.connect(l1AddrEOA).claimStake(
-          l2AddrEOA.address,
-          100,
-          0,
-          [],
-          ethers.constants.AddressZero,
-      );
+      const tx = l2Migrator
+          .connect(l1AddrEOA)
+          .claimStake(
+              l2AddrEOA.address,
+              100,
+              0,
+              [],
+              ethers.constants.AddressZero,
+          );
       expect(tx).to.revertedWith('L2Migrator#claimStake: ALREADY_MIGRATED');
     });
 
     it('reverts if fee transfer fails', async () => {
-      const tx = l2Migrator.connect(l1AddrEOA).claimStake(
-          l2AddrEOA.address,
-          100,
-          200,
-          [],
-          ethers.constants.AddressZero,
-      );
+      const tx = l2Migrator
+          .connect(l1AddrEOA)
+          .claimStake(
+              l2AddrEOA.address,
+              100,
+              200,
+              [],
+              ethers.constants.AddressZero,
+          );
       expect(tx).to.be.reverted;
     });
 
@@ -506,14 +512,21 @@ describe('L2Migrator', function() {
         params.l2Addr = l1AddrEOA.address;
         params.delegate = l1AddrEOA.address;
 
-        await l2Migrator.connect(mockL1MigratorL2AliasEOA).finalizeMigrateDelegator(params);
+        await l2Migrator
+            .connect(mockL1MigratorL2AliasEOA)
+            .finalizeMigrateDelegator(params);
 
-        const delegatorPoolAddr = await l2Migrator.delegatorPools(params.l1Addr);
+        const delegatorPoolAddr = await l2Migrator.delegatorPools(
+            params.l1Addr,
+        );
         expect(delegatorPoolAddr).to.not.be.equal(ethers.constants.AddressZero);
 
-        const delegatorPoolMock: FakeContract = await smock.fake('IDelegatorPool', {
-          address: delegatorPoolAddr,
-        });
+        const delegatorPoolMock: FakeContract = await smock.fake(
+            'IDelegatorPool',
+            {
+              address: delegatorPoolAddr,
+            },
+        );
 
         const delegator = l2AddrEOA;
         const delegate = l1AddrEOA.address;
@@ -522,17 +535,19 @@ describe('L2Migrator', function() {
 
         expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(0);
 
-        const tx = await l2Migrator.connect(delegator).claimStake(
-            delegate,
-            stake,
-            fees,
-            [],
-            ethers.constants.AddressZero,
-        );
+        const tx = await l2Migrator
+            .connect(delegator)
+            .claimStake(delegate, stake, fees, [], ethers.constants.AddressZero);
 
-        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be.true;
-        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(stake);
-        expect(delegatorPoolMock.claim).to.be.calledOnceWith(l2AddrEOA.address, 100);
+        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be
+            .true;
+        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(
+            stake,
+        );
+        expect(delegatorPoolMock.claim).to.be.calledOnceWith(
+            l2AddrEOA.address,
+            100,
+        );
 
         await expect(tx)
             .to.emit(l2Migrator, 'StakeClaimed')
@@ -545,19 +560,20 @@ describe('L2Migrator', function() {
         const stake = 100;
         const fees = 0;
 
-        expect(await l2Migrator.delegatorPools(delegate)).to.be.equal(ethers.constants.AddressZero);
-        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(0);
-
-        const tx = await l2Migrator.connect(delegator).claimStake(
-            delegate,
-            stake,
-            fees,
-            [],
+        expect(await l2Migrator.delegatorPools(delegate)).to.be.equal(
             ethers.constants.AddressZero,
         );
+        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(0);
 
-        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be.true;
-        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(stake);
+        const tx = await l2Migrator
+            .connect(delegator)
+            .claimStake(delegate, stake, fees, [], ethers.constants.AddressZero);
+
+        expect(await l2Migrator.migratedDelegators(delegator.address)).to.be
+            .true;
+        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(
+            stake,
+        );
         expect(bondingManagerMock.bondForWithHint).to.be.calledOnceWith(
             stake,
             delegator.address,
@@ -580,13 +596,9 @@ describe('L2Migrator', function() {
         const fees = 0;
         const newDelegate = l2Migrator.address;
 
-        const tx = await l2Migrator.connect(delegator).claimStake(
-            delegate,
-            stake,
-            fees,
-            [],
-            newDelegate,
-        );
+        const tx = await l2Migrator
+            .connect(delegator)
+            .claimStake(delegate, stake, fees, [], newDelegate);
 
         expect(bondingManagerMock.bondForWithHint).to.be.calledOnceWith(
             stake,
@@ -614,13 +626,9 @@ describe('L2Migrator', function() {
           value: ethers.utils.parseUnits('1', 'ether'),
         });
 
-        const tx = await l2Migrator.connect(delegator).claimStake(
-            delegate,
-            stake,
-            fees,
-            [],
-            ethers.constants.AddressZero,
-        );
+        const tx = await l2Migrator
+            .connect(delegator)
+            .claimStake(delegate, stake, fees, [], ethers.constants.AddressZero);
 
         await expect(tx).to.changeEtherBalance(delegator, fees);
       });


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Adds logic for claiming stake using a snapshot on L2.

Also, updates `finalizeMigrateDelegator()` to subtract already claimed delegated stake when staking for a newly created delegator pool.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Partially fixes livepeer/protocol#489.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
