### PR TITLE
L2: Update claimedDelegatedStake when finalizing migration

### DIFF
--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -114,6 +114,8 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
             emit DelegatorPoolCreated(_params.l1Addr, poolAddr);
         }
 
+        claimedDelegatedStake[_params.delegate] += _params.stake;
+
         // Use .call() since l2Addr could be a contract that needs more gas than
         // the stipend provided by .transfer()
         // The .call() is safe without a re-entrancy guard because this function cannot be re-entered

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -246,7 +246,7 @@ describe('L2Migrator', function() {
         // .withArgs(seqNo, params)
       });
 
-      it('subtracted claimed delegated stake when staking for delegator pool', async () => {
+      it('subtracts claimed delegated stake via claimStake() when staking for delegator pool', async () => {
         const delegator = l2AddrEOA;
         const delegate = l1AddrEOA.address;
         const stake = 50;
@@ -276,6 +276,51 @@ describe('L2Migrator', function() {
             params.delegatedStake - stake,
             delegatorPool,
             params.delegate,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+        );
+      });
+
+      it('subtracts claimed delegated stake via finalizeMigrateDelegator() when staking for delegator pool', async () => {
+        const delegator = l2AddrEOA.address;
+        const delegate = l1AddrEOA.address;
+        const stake = 50;
+
+        const params1 = {
+          ...mockMigrateDelegatorParams(),
+          l1Addr: delegator,
+          l2Addr: delegator,
+          delegate,
+          stake,
+        };
+        await l2Migrator
+            .connect(mockL1MigratorL2AliasEOA)
+            .finalizeMigrateDelegator(params1);
+
+        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(
+            stake,
+        );
+
+        const params2 = {
+          ...mockMigrateDelegatorParams(),
+          l1Addr: delegate,
+          l2Addr: delegate,
+          delegate,
+        };
+
+        bondingManagerMock.bondForWithHint.reset();
+
+        await l2Migrator
+            .connect(mockL1MigratorL2AliasEOA)
+            .finalizeMigrateDelegator(params2);
+
+        const delegatorPool = await l2Migrator.delegatorPools(params2.l1Addr);
+        expect(bondingManagerMock.bondForWithHint.atCall(1)).to.be.calledWith(
+            params2.delegatedStake - stake,
+            delegatorPool,
+            params2.delegate,
             ethers.constants.AddressZero,
             ethers.constants.AddressZero,
             ethers.constants.AddressZero,
@@ -533,7 +578,9 @@ describe('L2Migrator', function() {
         const stake = 100;
         const fees = 0;
 
-        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(0);
+        expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(
+            params.stake,
+        );
 
         const tx = await l2Migrator
             .connect(delegator)
@@ -542,7 +589,7 @@ describe('L2Migrator', function() {
         expect(await l2Migrator.migratedDelegators(delegator.address)).to.be
             .true;
         expect(await l2Migrator.claimedDelegatedStake(delegate)).to.be.equal(
-            stake,
+            params.stake + stake,
         );
         expect(delegatorPoolMock.claim).to.be.calledOnceWith(
             l2AddrEOA.address,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Fixes an issue where if `finalizeMigrateDelegator()` is called for a delegator from L1 before `finalizeMigrateDelegator()` is called for its orchestrator from L1 then the second tx would incorrectly include the delegator's stake in the delegated stake that is managed by the created delegator pool. We already increment `claimedDelegatedStake` in `claimStake()` to handle the scenario where a delegator calls that function before its orchestrator migrates. So, we address this issue by also incrementing `claimedDelegatedStake` in `finalizeMigrateDelegator()` to account for the scenario where a delegator does a cross-chain migration instead of a snapshot migration (i.e. via `claimStake()`).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
