### PR TITLE
L2: claimStakeEnabled flag in L2Migrator

### DIFF
--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -45,6 +45,7 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
 
     address public l1Migrator;
     address public delegatorPoolImpl;
+    bool public claimStakeEnabled;
 
     mapping(address => bool) public migratedDelegators;
     mapping(address => address) public delegatorPools;
@@ -87,6 +88,11 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
     }
 
     // TODO: Setter for delegatorPoolImpl?
+
+    // TODO: Add auth
+    function setClaimStakeEnabled(bool _enabled) external {
+        claimStakeEnabled = _enabled;
+    }
 
     function finalizeMigrateDelegator(MigrateDelegatorParams memory _params)
         external
@@ -174,6 +180,11 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator {
         bytes32[] calldata _proof,
         address _newDelegate
     ) external {
+        require(
+            claimStakeEnabled,
+            "L2Migrator#claimStake: CLAIM_STAKE_DISABLED"
+        );
+
         IMerkleSnapshot merkleSnapshot = IMerkleSnapshot(merkleSnapshotAddr);
 
         address delegator = msg.sender;


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Adds a `claimStakeEnabled` flag in the L2Migrator that by default is false and can be switched to true once the off-chain review period for the snapshot used in `claimStake()` is over. Originally, I thought we could delay storing the snapshot root in `MerkleSnapshot` until the end of the review period. But, given that the [merkle-earnings-cli tool](https://github.com/livepeer/merkle-earnings-cli) already reads the root to be validated from the `MerkleSnapshot` contract and given that it is generally easer to query for a root to be validated during the review period from the contract, I think it is easer to:

- Immediately store the root to be validated in the `MerkleSnapshot` contract such that anyone can query it with the snapshotID i.e. `keccak256("LIP-73")`
- Keep the `claimStakeEnabled` flag in the L2Migrator set to false during the review period
- Queue an update in the Governor that sets `claimStakeEnabled` to true that can be executed after the review period

Note: There is no auth for the new setter for the `claimStakeEnabled` flag yet. #32 is tracking the addition of auth for the entire contract.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
