### PR TITLE
L1/L2 LPTDataCache contracts for caching L1 total supply on L2

### DIFF
--- a/contracts/L1/gateway/L1LPTDataCache.sol
+++ b/contracts/L1/gateway/L1LPTDataCache.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {L1ArbitrumMessenger} from "./L1ArbitrumMessenger.sol";
+
+interface TotalSupplyLike {
+    function totalSupply() external view returns (uint256);
+}
+
+interface IL2LPTDataCache {
+    function finalizeCacheTotalSupply(uint256 _totalSupply) external;
+}
+
+contract L1LPTDataCache is L1ArbitrumMessenger {
+    address public immutable tokenAddr;
+    address public immutable l2LPTDataCacheAddr;
+
+    event CacheTotalSupplyInitiated(uint256 seqNo, uint256 totalSupply);
+
+    constructor(
+        address _inbox,
+        address _tokenAddr,
+        address _l2LPTDataCacheAddr
+    ) L1ArbitrumMessenger(_inbox) {
+        tokenAddr = _tokenAddr;
+        l2LPTDataCacheAddr = _l2LPTDataCacheAddr;
+    }
+
+    /**
+     * @notice Executes a L2 call to cache L1 LPT total supply in L2LPTDataCache
+     * @param _maxGas Gas limit for L2 execution
+     * @param _gasPriceBid Gas price bid for L2 execution
+     * @param _maxSubmissionCost Max ETH to pay for retryable ticket base submission fee
+     */
+    function cacheTotalSupply(
+        uint256 _maxGas,
+        uint256 _gasPriceBid,
+        uint256 _maxSubmissionCost
+    ) external payable {
+        (bytes memory data, uint256 totalSupply) = getCacheTotalSupplyData();
+
+        uint256 seqNo = sendTxToL2(
+            l2LPTDataCacheAddr,
+            msg.sender, // Refund to caller
+            _maxSubmissionCost,
+            _maxGas,
+            _gasPriceBid,
+            data
+        );
+
+        emit CacheTotalSupplyInitiated(seqNo, totalSupply);
+    }
+
+    /**
+     * @notice Return L2 calldata and total supply to use for a L2 call on L2LPTDataCache
+     * @return data L2 calldata for L2LPTDataCache
+     * @return totalSupply L1 LPT total supply
+     */
+    function getCacheTotalSupplyData()
+        public
+        view
+        returns (bytes memory data, uint256 totalSupply)
+    {
+        totalSupply = TotalSupplyLike(tokenAddr).totalSupply();
+
+        data = abi.encodeWithSelector(
+            IL2LPTDataCache.finalizeCacheTotalSupply.selector,
+            totalSupply
+        );
+    }
+}

--- a/contracts/L2/gateway/L2LPTDataCache.sol
+++ b/contracts/L2/gateway/L2LPTDataCache.sol
@@ -55,7 +55,15 @@ contract L2LPTDataCache is Ownable, L2ArbitrumMessenger {
      * @param _amount Amount to decrease l2SupplyFromL1
      */
     function decreaseL2SupplyFromL1(uint256 _amount) external onlyL2LPTGateway {
-        l2SupplyFromL1 -= _amount;
+        // If there is a mass withdrawal from L2, _amount could exceed l2SupplyFromL1.
+        // In this case, we just set l2SupplyFromL1 = 0 because there will be no more supply on L2
+        // that is from L1 and the excess (_amount - l2SupplyFromL1) is inflationary LPT that was
+        // never from L1 in the first place.
+        if (_amount > l2SupplyFromL1) {
+            l2SupplyFromL1 = 0;
+        } else {
+            l2SupplyFromL1 -= _amount;
+        }
 
         // No event because the L2LPTGateway events are sufficient
     }

--- a/contracts/L2/gateway/L2LPTDataCache.sol
+++ b/contracts/L2/gateway/L2LPTDataCache.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {L2ArbitrumMessenger} from "./L2ArbitrumMessenger.sol";
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract L2LPTDataCache is Ownable, L2ArbitrumMessenger {
+    address public l1LPTDataCache;
+    address public l2LPTGateway;
+
+    // Total supply of LPT on L1
+    // Updates are initiated by a call from the L1LPTDataCache on L1
+    uint256 public l1TotalSupply;
+    // Amount of L2 LPT transferred from L1 via the LPT bridge
+    uint256 public l2SupplyFromL1;
+
+    event CacheTotalSupplyFinalized(uint256 totalSupply);
+
+    modifier onlyL2LPTGateway() {
+        require(msg.sender == l2LPTGateway, "NOT_L2_LPT_GATEWAY");
+        _;
+    }
+
+    /**
+     * @notice Sets the L1LPTDataCache
+     * @param _l1LPTDataCache L1 address of L1LPTDataCache
+     */
+    function setL1LPTDataCache(address _l1LPTDataCache) external onlyOwner {
+        l1LPTDataCache = _l1LPTDataCache;
+    }
+
+    /**
+     * @notice Sets the L2LPTGateway
+     * @param _l2LPTGateway L2 address of L2LPTGateway
+     */
+    function setL2LPTGateway(address _l2LPTGateway) external onlyOwner {
+        l2LPTGateway = _l2LPTGateway;
+    }
+
+    /**
+     * @notice Called by L2LPTGateway to increase l2SupplyFromL1
+     * @dev Should be called when L2LPTGateway mints LPT to ensure that L2 total supply and l2SupplyFromL1 increase by the same amount
+     * @param _amount Amount to increase l2SupplyFromL1
+     */
+    function increaseL2SupplyFromL1(uint256 _amount) external onlyL2LPTGateway {
+        l2SupplyFromL1 += _amount;
+
+        // No event because the L2LPTGateway events are sufficient
+    }
+
+    /**
+     * @notice Called by L2LPTGateway to decrease l2SupplyFromL1
+     * @dev Should be called when L2LPTGateway burns LPT ensure L2 total supply and l2SupplyFromL1 decrease by the same amount
+     * @param _amount Amount to decrease l2SupplyFromL1
+     */
+    function decreaseL2SupplyFromL1(uint256 _amount) external onlyL2LPTGateway {
+        l2SupplyFromL1 -= _amount;
+
+        // No event because the L2LPTGateway events are sufficient
+    }
+
+    /**
+     * @notice Called by L1LPTDataCache from L1 to cache L1 LPT total supply
+     * @param _totalSupply L1 LPT total supply
+     */
+    function finalizeCacheTotalSupply(uint256 _totalSupply)
+        external
+        onlyL1Counterpart(l1LPTDataCache)
+    {
+        l1TotalSupply = _totalSupply;
+
+        emit CacheTotalSupplyFinalized(_totalSupply);
+    }
+
+    /**
+     * @notice Calculate and return L1 LPT circulating supply
+     * @return L1 LPT circulating supply
+     */
+    function l1CirculatingSupply() public view returns (uint256) {
+        // After the first update from L1, l1TotalSupply should always be >= l2SupplyFromL1
+        // The below check is defensive to avoid reverting if this invariant for some reason violated
+        return
+            l1TotalSupply >= l2SupplyFromL1
+                ? l1TotalSupply - l2SupplyFromL1
+                : 0;
+    }
+}

--- a/test/unit/L1/l1LPTDataCache.test.ts
+++ b/test/unit/L1/l1LPTDataCache.test.ts
@@ -1,0 +1,137 @@
+import {FakeContract, smock} from '@defi-wonderland/smock';
+import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/dist/src/signers';
+import {expect, use} from 'chai';
+import {ethers} from 'hardhat';
+import {
+  IL2LPTDataCache__factory,
+  L1LPTDataCache,
+  L1LPTDataCache__factory,
+} from '../../../typechain';
+
+use(smock.matchers);
+
+describe('L1LPTDataCache', () => {
+  let l1LPTDataCache: L1LPTDataCache;
+
+  let l1EOA: SignerWithAddress;
+
+  let inboxMock: FakeContract;
+  let outboxMock: FakeContract;
+  let bridgeMock: FakeContract;
+  let tokenMock: FakeContract;
+  let mockInboxEOA: SignerWithAddress;
+  let mockOutboxEOA: SignerWithAddress;
+  let mockBridgeEOA: SignerWithAddress;
+  let mockTokenEOA: SignerWithAddress;
+  let mockL2LPTDataCacheEOA: SignerWithAddress;
+
+  beforeEach(async function() {
+    [
+      l1EOA,
+      mockInboxEOA,
+      mockOutboxEOA,
+      mockBridgeEOA,
+      mockTokenEOA,
+      mockL2LPTDataCacheEOA,
+    ] = await ethers.getSigners();
+
+    const L1LPTDataCache: L1LPTDataCache__factory =
+      await ethers.getContractFactory('L1LPTDataCache');
+    l1LPTDataCache = await L1LPTDataCache.deploy(
+        mockInboxEOA.address,
+        mockTokenEOA.address,
+        mockL2LPTDataCacheEOA.address,
+    );
+    await l1LPTDataCache.deployed();
+
+    inboxMock = await smock.fake('IInbox', {
+      address: mockInboxEOA.address,
+    });
+
+    outboxMock = await smock.fake('IOutbox', {
+      address: mockOutboxEOA.address,
+    });
+
+    bridgeMock = await smock.fake('IBridge', {
+      address: mockBridgeEOA.address,
+    });
+
+    tokenMock = await smock.fake('TotalSupplyLike', {
+      address: mockTokenEOA.address,
+    });
+
+    inboxMock.bridge.returns(bridgeMock.address);
+    bridgeMock.activeOutbox.returns(outboxMock.address);
+  });
+
+  describe('constructor', () => {
+    it('sets addresses', async () => {
+      expect(await l1LPTDataCache.inbox()).to.be.equal(mockInboxEOA.address);
+      expect(await l1LPTDataCache.tokenAddr()).to.be.equal(
+          mockTokenEOA.address,
+      );
+      expect(await l1LPTDataCache.l2LPTDataCacheAddr()).to.be.equal(
+          mockL2LPTDataCacheEOA.address,
+      );
+    });
+  });
+
+  describe('cacheTotalSupply', () => {
+    it('sends retryable ticket', async () => {
+      const seqNo = 7;
+      const totalSupply = 1000;
+
+      inboxMock.createRetryableTicket.returns(seqNo);
+      tokenMock.totalSupply.returns(totalSupply);
+
+      const maxGas = 111;
+      const gasPriceBid = 222;
+      const maxSubmissionCost = 333;
+      const l1CallValue = 444;
+
+      const l2Calldata =
+        IL2LPTDataCache__factory.createInterface().encodeFunctionData(
+            'finalizeCacheTotalSupply',
+            [totalSupply],
+        );
+
+      const tx = await l1LPTDataCache
+          .connect(l1EOA)
+          .cacheTotalSupply(maxGas, gasPriceBid, maxSubmissionCost, {
+            value: l1CallValue,
+          });
+
+      expect(inboxMock.createRetryableTicket).to.be.calledOnceWith(
+          mockL2LPTDataCacheEOA.address,
+          0,
+          maxSubmissionCost,
+          l1EOA.address,
+          l1EOA.address,
+          maxGas,
+          gasPriceBid,
+          l2Calldata,
+      );
+      await expect(tx)
+          .to.emit(l1LPTDataCache, 'CacheTotalSupplyInitiated')
+          .withArgs(seqNo, totalSupply);
+    });
+  });
+
+  describe('getCacheTotalSupplyData', () => {
+    it('returns L2 calldata and total supply', async () => {
+      const totalSupply = 1000;
+
+      tokenMock.totalSupply.returns(totalSupply);
+
+      const l2Calldata =
+        IL2LPTDataCache__factory.createInterface().encodeFunctionData(
+            'finalizeCacheTotalSupply',
+            [totalSupply],
+        );
+
+      const res = await l1LPTDataCache.getCacheTotalSupplyData();
+      expect(res.data).to.be.equal(l2Calldata);
+      expect(res.totalSupply).to.be.equal(totalSupply);
+    });
+  });
+});

--- a/test/unit/L2/l2LPTDataCache.test.ts
+++ b/test/unit/L2/l2LPTDataCache.test.ts
@@ -7,9 +7,6 @@ import {getL2SignerFromL1} from '../../utils/messaging';
 
 use(smock.matchers);
 
-const UNDERFLOW_ERR =
-  'panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)';
-
 describe('L2LPTDataCache', () => {
   let l2LPTDataCache: L2LPTDataCache;
 
@@ -113,10 +110,21 @@ describe('L2LPTDataCache', () => {
       );
     });
 
-    it('reverts if specified amount > l2SupplyFromL1', async () => {
+    it('sets l2SupplyFromL1 to 0 if amount > l2SupplyFromL1', async () => {
+      // l2SupplyFromL1 = 0
       await expect(
           l2LPTDataCache.connect(mockL2LPTGatewayEOA).decreaseL2SupplyFromL1(100),
-      ).to.be.revertedWith(UNDERFLOW_ERR);
+      ).to.not.be.reverted;
+      expect(await l2LPTDataCache.l2SupplyFromL1()).to.be.equal(0);
+
+      // l2SupplyFromL1 > 0
+      await l2LPTDataCache
+          .connect(mockL2LPTGatewayEOA)
+          .increaseL2SupplyFromL1(99);
+      await expect(
+          l2LPTDataCache.connect(mockL2LPTGatewayEOA).decreaseL2SupplyFromL1(100),
+      ).to.not.be.reverted;
+      expect(await l2LPTDataCache.l2SupplyFromL1()).to.be.equal(0);
     });
 
     it('decreases l2SupplyFromL1 by specified amount', async () => {

--- a/test/unit/L2/l2LPTDataCache.test.ts
+++ b/test/unit/L2/l2LPTDataCache.test.ts
@@ -1,0 +1,251 @@
+import {smock} from '@defi-wonderland/smock';
+import {SignerWithAddress} from '@nomiclabs/hardhat-ethers/dist/src/signers';
+import {expect, use} from 'chai';
+import {ethers} from 'hardhat';
+import {L2LPTDataCache, L2LPTDataCache__factory} from '../../../typechain';
+import {getL2SignerFromL1} from '../../utils/messaging';
+
+use(smock.matchers);
+
+const UNDERFLOW_ERR =
+  'panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)';
+
+describe('L2LPTDataCache', () => {
+  let l2LPTDataCache: L2LPTDataCache;
+
+  let deployer: SignerWithAddress;
+  let notDeployer: SignerWithAddress;
+
+  let mockL1LPTDataCacheEOA: SignerWithAddress;
+  let mockL1LPTDataCacheL2AliasEOA: SignerWithAddress;
+  let mockL2LPTGatewayEOA: SignerWithAddress;
+
+  beforeEach(async function() {
+    [deployer, notDeployer, mockL1LPTDataCacheEOA, mockL2LPTGatewayEOA] =
+      await ethers.getSigners();
+
+    const L2LPTDataCache: L2LPTDataCache__factory =
+      await ethers.getContractFactory('L2LPTDataCache');
+    l2LPTDataCache = await L2LPTDataCache.deploy();
+    await l2LPTDataCache.deployed();
+
+    await l2LPTDataCache.setL1LPTDataCache(mockL1LPTDataCacheEOA.address);
+    await l2LPTDataCache.setL2LPTGateway(mockL2LPTGatewayEOA.address);
+
+    mockL1LPTDataCacheL2AliasEOA = await getL2SignerFromL1(
+        mockL1LPTDataCacheEOA,
+    );
+    await mockL1LPTDataCacheEOA.sendTransaction({
+      to: mockL1LPTDataCacheL2AliasEOA.address,
+      value: ethers.utils.parseUnits('1', 'ether'),
+    });
+  });
+
+  describe('constructor', () => {
+    it('sets owner to deployer', async () => {
+      expect(await l2LPTDataCache.owner()).to.be.equal(deployer.address);
+    });
+  });
+
+  describe('setL1LPTDataCache', () => {
+    it('reverts if msg.sender != owner', async () => {
+      await expect(
+          l2LPTDataCache
+              .connect(notDeployer)
+              .setL1LPTDataCache(ethers.constants.AddressZero),
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it('sets L1LPTDataCache', async () => {
+      await l2LPTDataCache.setL1LPTDataCache(ethers.constants.AddressZero);
+      expect(await l2LPTDataCache.l1LPTDataCache()).to.be.equal(
+          ethers.constants.AddressZero,
+      );
+    });
+  });
+
+  describe('setL2LPTGateway', () => {
+    it('reverts if msg.sender != owner', async () => {
+      await expect(
+          l2LPTDataCache
+              .connect(notDeployer)
+              .setL2LPTGateway(ethers.constants.AddressZero),
+      ).to.be.revertedWith('Ownable: caller is not the owner');
+    });
+
+    it('sets L2LPTGateway', async () => {
+      await l2LPTDataCache.setL2LPTGateway(ethers.constants.AddressZero);
+      expect(await l2LPTDataCache.l2LPTGateway()).to.be.equal(
+          ethers.constants.AddressZero,
+      );
+    });
+  });
+
+  describe('increaseL2SupplyFromL1', () => {
+    it('reverts if msg.sender != L2LPTGateway', async () => {
+      await expect(l2LPTDataCache.increaseL2SupplyFromL1(1)).to.be.revertedWith(
+          'NOT_L2_LPT_GATEWAY',
+      );
+    });
+
+    it('increases l2SupplyFromL1 by specified amount', async () => {
+      const amount0 = 100;
+      const amount1 = 200;
+
+      await l2LPTDataCache
+          .connect(mockL2LPTGatewayEOA)
+          .increaseL2SupplyFromL1(amount0);
+      expect(await l2LPTDataCache.l2SupplyFromL1()).to.be.equal(amount0);
+
+      await l2LPTDataCache
+          .connect(mockL2LPTGatewayEOA)
+          .increaseL2SupplyFromL1(amount1);
+      expect(await l2LPTDataCache.l2SupplyFromL1()).to.be.equal(
+          amount0 + amount1,
+      );
+    });
+  });
+
+  describe('decreaseL2SupplyFromL1', () => {
+    it('reverts if msg.sender != L2LPTGateway', async () => {
+      await expect(l2LPTDataCache.decreaseL2SupplyFromL1(1)).to.be.revertedWith(
+          'NOT_L2_LPT_GATEWAY',
+      );
+    });
+
+    it('reverts if specified amount > l2SupplyFromL1', async () => {
+      await expect(
+          l2LPTDataCache.connect(mockL2LPTGatewayEOA).decreaseL2SupplyFromL1(100),
+      ).to.be.revertedWith(UNDERFLOW_ERR);
+    });
+
+    it('decreases l2SupplyFromL1 by specified amount', async () => {
+      const initAmount = 1000;
+      const amount0 = 100;
+      const amount1 = 200;
+
+      await l2LPTDataCache
+          .connect(mockL2LPTGatewayEOA)
+          .increaseL2SupplyFromL1(initAmount);
+      expect(await l2LPTDataCache.l2SupplyFromL1()).to.be.equal(initAmount);
+
+      await l2LPTDataCache
+          .connect(mockL2LPTGatewayEOA)
+          .decreaseL2SupplyFromL1(amount0);
+      expect(await l2LPTDataCache.l2SupplyFromL1()).to.be.equal(
+          initAmount - amount0,
+      );
+
+      await l2LPTDataCache
+          .connect(mockL2LPTGatewayEOA)
+          .decreaseL2SupplyFromL1(amount1);
+      expect(await l2LPTDataCache.l2SupplyFromL1()).to.be.equal(
+          initAmount - amount0 - amount1,
+      );
+    });
+  });
+
+  describe('finalizeCacheTotalSupply', () => {
+    it('reverts if msg.sender != L1LPTDataCache L2 alias', async () => {
+      // msg.sender = some invalid address
+      await expect(
+          l2LPTDataCache.finalizeCacheTotalSupply(100),
+      ).to.be.revertedWith('ONLY_COUNTERPART_GATEWAY');
+
+      // msg.sender = L1LPTDataCache (no alias)
+      await expect(
+          l2LPTDataCache
+              .connect(mockL1LPTDataCacheEOA)
+              .finalizeCacheTotalSupply(100),
+      ).to.be.revertedWith('ONLY_COUNTERPART_GATEWAY');
+    });
+
+    it('caches total supply', async () => {
+      const totalSupply0 = 100;
+      const totalSupply1 = 200;
+
+      let tx = await l2LPTDataCache
+          .connect(mockL1LPTDataCacheL2AliasEOA)
+          .finalizeCacheTotalSupply(totalSupply0);
+      expect(await l2LPTDataCache.l1TotalSupply()).to.be.equal(totalSupply0);
+      await expect(tx)
+          .to.emit(l2LPTDataCache, 'CacheTotalSupplyFinalized')
+          .withArgs(totalSupply0);
+
+      tx = await l2LPTDataCache
+          .connect(mockL1LPTDataCacheL2AliasEOA)
+          .finalizeCacheTotalSupply(totalSupply1);
+      expect(await l2LPTDataCache.l1TotalSupply()).to.be.equal(totalSupply1);
+      await expect(tx)
+          .to.emit(l2LPTDataCache, 'CacheTotalSupplyFinalized')
+          .withArgs(totalSupply1);
+    });
+  });
+
+  describe('l1CirculatingSupply', () => {
+    it('returns 0 if l1TotalSupply == l2SupplyFromL1', async () => {
+      expect(await l2LPTDataCache.l1CirculatingSupply()).to.be.equal(0);
+    });
+
+    it('returns 0 if l1TotalSupply < l2SupplyFromL1', async () => {
+      // l1TotalSupply = 0
+      await l2LPTDataCache
+          .connect(mockL2LPTGatewayEOA)
+          .increaseL2SupplyFromL1(100);
+      expect(await l2LPTDataCache.l1CirculatingSupply()).to.be.equal(0);
+
+      // l1TotalSupply > 0
+      await l2LPTDataCache
+          .connect(mockL1LPTDataCacheL2AliasEOA)
+          .finalizeCacheTotalSupply(50);
+      expect(await l2LPTDataCache.l1CirculatingSupply()).to.be.equal(0);
+    });
+
+    it('calculates and returns L1 circulating supply', async () => {
+      const l1TotalSupply = 100;
+      const l2SupplyFromL1 = 50;
+
+      await l2LPTDataCache
+          .connect(mockL2LPTGatewayEOA)
+          .increaseL2SupplyFromL1(l2SupplyFromL1);
+      await l2LPTDataCache
+          .connect(mockL1LPTDataCacheL2AliasEOA)
+          .finalizeCacheTotalSupply(l1TotalSupply);
+      expect(await l2LPTDataCache.l1CirculatingSupply()).to.be.equal(
+          l1TotalSupply - l2SupplyFromL1,
+      );
+
+      // Increase l2SupplyFromL1 -> decrease circulating supply
+      await l2LPTDataCache
+          .connect(mockL2LPTGatewayEOA)
+          .increaseL2SupplyFromL1(1);
+      expect(await l2LPTDataCache.l1CirculatingSupply()).to.be.equal(
+          l1TotalSupply - l2SupplyFromL1 - 1,
+      );
+
+      // Decrease l2SupplyFromL1 -> increase circulating supply
+      await l2LPTDataCache
+          .connect(mockL2LPTGatewayEOA)
+          .decreaseL2SupplyFromL1(1);
+      expect(await l2LPTDataCache.l1CirculatingSupply()).to.be.equal(
+          l1TotalSupply - l2SupplyFromL1,
+      );
+
+      // Increase l1TotalSupply -> increase circulating supply
+      await l2LPTDataCache
+          .connect(mockL1LPTDataCacheL2AliasEOA)
+          .finalizeCacheTotalSupply(l1TotalSupply + 1);
+      expect(await l2LPTDataCache.l1CirculatingSupply()).to.be.equal(
+          l1TotalSupply - l2SupplyFromL1 + 1,
+      );
+
+      // Decrease l1TotalSupply -> decrease circulating supply
+      await l2LPTDataCache
+          .connect(mockL1LPTDataCacheL2AliasEOA)
+          .finalizeCacheTotalSupply(l1TotalSupply);
+      expect(await l2LPTDataCache.l1CirculatingSupply()).to.be.equal(
+          l1TotalSupply - l2SupplyFromL1,
+      );
+    });
+  });
+});


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR introduces a L1/L2 LPTDataCache contracts used to support:

- Caching the L1 total supply on L2 so that L2 contracts can access it
- Calculating the L1 circulating supply on L2 based on the L1 total supply and the L2 supply from L1

Originally, the plan was to calculate the L1 circulating supply on L1 and then cache that value on L2 whenever the L1 circulating supply on L1 changes. However, assuming `l1CirculatingSupply =  L1LPT.totalSupply() - L1LPT.balanceOf(L1Escrow)`, the value would change whenever LPT is added to the L1Escrow. However, this wouldn't result in a change in the global total supply calculated on L2 because the L2 total supply would increase by the same amount of LPT that is added to the L1Escrow after the retryable ticket to L2 is executed. So, an off-chain process that is responsible for updating the cache would need to have more complex logic to determine when the cache should be updated.

The approach in this PR is to cache the L1 total supply on L2 instead of the L1 circulating supply. It is much easier for an off-chain process to determine when the cache needs to be updated in this scenario - whenever the L1 total supply changes. After Confluence, this should only happen if someone burns their own LPT (which seems unlikely to ever happen which means updates to the cache may never be needed in practice!). The L2LPTDataCache then calculates the L1 circulating supply by keeping track of how much LPT on L2 is from L1. This is accomplished by having the L2LPTGateway update a variable in L2LPTDataCache whenever it mints LPT on L2 (someone transferred LPT to L2) or burns LPT on L2 (someone transferred LPT to L1).

The important formulas:

- `l1CirculatingSupply =  L2LPTDataCache.l1TotalSupply() - L2LPTDataCache.l2SupplyFromL1()`
- `globalTotalSupply = L2LPT.totalSupply() + L2LPTDataCache.l1CirculatingSupply()`
- `L2LPTDataCache.l1CirculatingSupply() = L2LPTDataCache.l1TotalSupply() - L2LPTDataCache.l2SupplyFromL1()`

where

- `L2LPTDataCache.l1TotalSupply()` is updated via the L1LPTDataCache via a L1 -> L2 call
- `L2LPTDataCache.l2SupplyFromL1()` is updated via L2LPTGateway on LPT mint/burn

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #27 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
