### PR TITLE
added auth in migrator contracts

### DIFF
--- a/contracts/L1/gateway/L1Migrator.sol
+++ b/contracts/L1/gateway/L1Migrator.sol
@@ -150,7 +150,7 @@ contract L1Migrator is
         uint256 _maxGas,
         uint256 _gasPriceBid,
         uint256 _maxSubmissionCost
-    ) external payable {
+    ) external payable whenNotPaused {
         requireValidMigration(
             _l1Addr,
             _l2Addr,
@@ -185,7 +185,7 @@ contract L1Migrator is
         uint256 _maxGas,
         uint256 _gasPriceBid,
         uint256 _maxSubmissionCost
-    ) external payable {
+    ) external payable whenNotPaused {
         requireValidMigration(
             _l1Addr,
             _l2Addr,
@@ -224,7 +224,7 @@ contract L1Migrator is
         uint256 _maxGas,
         uint256 _gasPriceBid,
         uint256 _maxSubmissionCost
-    ) external payable {
+    ) external payable whenNotPaused {
         requireValidMigration(
             _l1Addr,
             _l2Addr,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Added access control and ability to pause to L1 and L2 Migrator contracts. 

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Added `whenNotPaused` modifier to migrate functions and made the contract to be in paused state on deployment.
- Added only governor modifier to setClaimStakeEnabled

**_For Reviewer_**
The l1Migrator.test.ts diff is large because I wrapped the tests into 2 sections -
1. migrator is paused
2. migrator is not paused
There are no changes in 2nd section except a beforeEach hook which calls `unpause` on the contract

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
ran `yarn test`

**Does this pull request close any open issues?**
<!-- Fixes # -->
closes #32 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
