### PR TITLE
added receive function to l1Migrator

### DIFF
--- a/contracts/L1/gateway/L1Migrator.sol
+++ b/contracts/L1/gateway/L1Migrator.sol
@@ -323,7 +323,7 @@ contract L1Migrator is
         sendTxToL2(
             l2MigratorAddr,
             address(this), // L2 alias of this contract will receive refunds
-            msg.value,
+            msg.value + amount,
             amount,
             _maxSubmissionCost,
             _maxGas,

--- a/contracts/L1/gateway/L1Migrator.sol
+++ b/contracts/L1/gateway/L1Migrator.sol
@@ -144,7 +144,7 @@ contract L1Migrator is
     }
 
     /**
-     * @notice receive ETH from BridgeMinter.
+     * @notice Receive ETH when there is no msg.data
      */
     receive() external payable {}
 

--- a/contracts/L1/gateway/L1Migrator.sol
+++ b/contracts/L1/gateway/L1Migrator.sol
@@ -144,6 +144,11 @@ contract L1Migrator is
     }
 
     /**
+     * @notice receive ETH from BridgeMinter.
+     */
+    receive() external payable {}
+
+    /**
      * @notice Executes a L2 call to L2Migrator to migrate transcoder/delegator state from the L1 BondingManager.
      * @dev The term "delegator" here can refer to both a transcoder (self-delegated delegator) and delegator.
      * @param _l1Addr Address migrating from L1

--- a/test/unit/L1/l1Migrator.test.ts
+++ b/test/unit/L1/l1Migrator.test.ts
@@ -851,6 +851,10 @@ describe('L1Migrator', function() {
 
         bridgeMinterMock.withdrawETHToL1Migrator.returns(amount);
         inboxMock.createRetryableTicket.returns(seqNo);
+        await l1EOA.sendTransaction({
+          to: l1Migrator.address,
+          value: amount,
+        });
 
         const maxGas = 111;
         const gasPriceBid = 222;
@@ -863,6 +867,7 @@ describe('L1Migrator', function() {
               value: l1CallValue,
             });
 
+        await expect(tx).to.changeEtherBalance(inboxMock, amount + l1CallValue);
         expect(bridgeMinterMock.withdrawETHToL1Migrator).to.be.calledOnce;
         expect(inboxMock.createRetryableTicket).to.be.calledOnceWith(
             mockL2MigratorEOA.address,

--- a/test/unit/L1/l1Migrator.test.ts
+++ b/test/unit/L1/l1Migrator.test.ts
@@ -804,6 +804,18 @@ describe('L1Migrator', function() {
     });
   });
 
+  describe('receive', () => {
+    it('receives ETH', async () => {
+      const value = ethers.utils.parseUnits('1', 'ether');
+      const tx = await l1EOA.sendTransaction({
+        to: l1Migrator.address,
+        value,
+      });
+
+      await expect(tx).to.changeEtherBalance(l1Migrator, value);
+    });
+  });
+
   describe('migrateETH', () => {
     describe('migrator is paused', () => {
       it('fails to send tx to L2', async () => {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
L1 Migrator Contract was unable to receive ETH when `withdrawETHToL1Migrator` function was called due to lack of fallback function on the contract. This PR adds `receive` function to L1 Migrator.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adds `receive()` function to L1 Migrator
- updated tests to test for receive function

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
ran default test suite

**Does this pull request close any open issues?**
<!-- Fixes # -->
https://github.com/code-423n4/2022-01-livepeer-findings/issues/198

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
