### PR TITLE
updated L1 callvalue param for migrateETH tx

### DIFF
--- a/contracts/L1/gateway/L1Migrator.sol
+++ b/contracts/L1/gateway/L1Migrator.sol
@@ -323,7 +323,7 @@ contract L1Migrator is
         sendTxToL2(
             l2MigratorAddr,
             address(this), // L2 alias of this contract will receive refunds
-            msg.value,
+            msg.value + amount,
             amount,
             _maxSubmissionCost,
             _maxGas,

--- a/test/unit/L1/l1Migrator.test.ts
+++ b/test/unit/L1/l1Migrator.test.ts
@@ -851,6 +851,10 @@ describe('L1Migrator', function() {
 
         bridgeMinterMock.withdrawETHToL1Migrator.returns(amount);
         inboxMock.createRetryableTicket.returns(seqNo);
+        await l1EOA.sendTransaction({
+          to: l1Migrator.address,
+          value: amount,
+        });
 
         const maxGas = 111;
         const gasPriceBid = 222;
@@ -863,6 +867,7 @@ describe('L1Migrator', function() {
               value: l1CallValue,
             });
 
+        await expect(tx).to.changeEtherBalance(inboxMock, amount + l1CallValue);
         expect(bridgeMinterMock.withdrawETHToL1Migrator).to.be.calledOnce;
         expect(inboxMock.createRetryableTicket).to.be.calledOnceWith(
             mockL2MigratorEOA.address,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
L1 Migrator contract was sending incorrect amount of ETH to the inbox when `migrateETH` function was called. The amount transferred should be equal to the msg.value (used to execute L2 tx) + the amount of ETH withdrawn from the Minter contract.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- updated param to correctly set L1 callvalue for sendTx2L2 function
- updated tests to test the change

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
ran test suite

**Does this pull request close any open issues?**
<!-- Fixes # -->
https://github.com/code-423n4/2022-01-livepeer-findings/issues/205

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
