### PR TITLE
L1: Use max uint256 for _endRound in pendingStake/Fees

### DIFF
--- a/contracts/L1/gateway/L1Migrator.sol
+++ b/contracts/L1/gateway/L1Migrator.sol
@@ -386,10 +386,12 @@ contract L1Migrator is
     {
         IBondingManager bondingManager = IBondingManager(bondingManagerAddr);
 
-        // pendingStake() ignores the _endRound arg
-        uint256 stake = bondingManager.pendingStake(_l1Addr, 0);
-        // pendingFees() ignores the _endRound arg
-        uint256 fees = bondingManager.pendingFees(_l1Addr, 0);
+        // pendingStake() will use current round if _endRound >= LIP-36 round
+        // Using max uint256 guarantees that
+        uint256 stake = bondingManager.pendingStake(_l1Addr, type(uint256).max);
+        // pendingFees() will use current round if _endRound >= LIP-36 round
+        // Using max uint256 guarantees that
+        uint256 fees = bondingManager.pendingFees(_l1Addr, type(uint256).max);
         (
             ,
             ,

--- a/test/unit/L1/l1Migrator.test.ts
+++ b/test/unit/L1/l1Migrator.test.ts
@@ -398,8 +398,12 @@ describe('L1Migrator', function() {
         const delegate = notL1EOA.address;
 
         inboxMock.createRetryableTicket.returns(seqNo);
-        bondingManagerMock.pendingStake.returns(stake);
-        bondingManagerMock.pendingFees.returns(fees);
+        bondingManagerMock.pendingStake
+            .whenCalledWith(l1EOA.address, ethers.constants.MaxUint256)
+            .returns(stake);
+        bondingManagerMock.pendingFees
+            .whenCalledWith(l1EOA.address, ethers.constants.MaxUint256)
+            .returns(fees);
         bondingManagerMock.getDelegator.returns([
           0,
           0,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes a bug with the usage of pendingStake/pendingFees in L1Migrator.

Previously, the _endRound arg of these functions was set to 0. This would be fine if the L1Migrator was calling the L2 BondingManager which ignores the _endRound arg and always sets the end round for the calculation to the current round [1]. However, the L1Migrator calls the L1 BondingManager which does not always ignore the _endRound arg and only sets the end round for the calculation to the current round if the _endRound value >= the LIP-36 round [2]. So, if we pass 0 in the L1Migrator for this arg, the internal end round for the calculation would not be properly set if the LIP-36 round > 0. So, the fix is to pass max uint256 for the _endRound arg which should always be >= the LIP-36 round ensuring that the calculation in pendingStake/Fees uses the current round internally.

[1] https://github.com/livepeer/protocol/blob/439445f3ab6ef88f490ee2fdafb84c7d8fee76f3/contracts/bonding/BondingManager.sol#L788
[2] https://github.com/livepeer/protocol/blob/20e7ebb86cdb4fe9285bf5fea02eb603e5d48805/contracts/bonding/BondingManager.sol#L825

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
