### PR TITLE
L2: Only non-self delegated stake for DelegatorPool in L2Migrator

### DIFF
--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -142,15 +142,19 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator, AccessControl {
             // l1Addr is an orchestrator on L1:
             // 1. Stake _params.stake on behalf of _params.l2Addr
             // 2. Create delegator pool
-            // 3. Stake _params.delegatedStake on behalf of the delegator pool
+            // 3. Stake non-self delegated stake on behalf of the delegator pool
             bondFor(_params.stake, _params.l2Addr, _params.delegate);
 
             address poolAddr = Clones.clone(delegatorPoolImpl);
 
             delegatorPools[_params.l1Addr] = poolAddr;
 
+            // _params.delegatedStake includes _params.stake which is the orchestrator's self-stake
+            // Subtract _params.stake to get the orchestrator's non-self delegated stake
+            uint256 nonSelfDelegatedStake = _params.delegatedStake -
+                _params.stake;
             bondFor(
-                _params.delegatedStake - claimedDelegatedStake[_params.l1Addr],
+                nonSelfDelegatedStake - claimedDelegatedStake[_params.l1Addr],
                 poolAddr,
                 _params.delegate
             );

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -322,7 +322,7 @@ describe('L2Migrator', function() {
           );
 
           expect(bondingManagerMock.bondForWithHint.atCall(1)).to.be.calledWith(
-              params.delegatedStake,
+              params.delegatedStake - params.stake,
               delegatorPool,
               params.delegate,
               ethers.constants.AddressZero,
@@ -373,7 +373,7 @@ describe('L2Migrator', function() {
 
           const delegatorPool = await l2Migrator.delegatorPools(params.l1Addr);
           expect(bondingManagerMock.bondForWithHint.atCall(1)).to.be.calledWith(
-              params.delegatedStake - stake,
+              params.delegatedStake - params.stake - stake,
               delegatorPool,
               params.delegate,
               ethers.constants.AddressZero,
@@ -418,7 +418,7 @@ describe('L2Migrator', function() {
 
           const delegatorPool = await l2Migrator.delegatorPools(params2.l1Addr);
           expect(bondingManagerMock.bondForWithHint.atCall(1)).to.be.calledWith(
-              params2.delegatedStake - stake,
+              params2.delegatedStake - params2.stake - stake,
               delegatorPool,
               params2.delegate,
               ethers.constants.AddressZero,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes an issue where the L2Migrator adds an orchestrator's entire delegated stake for a newly created DelegatorPool in `finalizeMigrateDelegator()`. The L2Migrator should only add an orchestrator's non-self delegated stake for the DelegatorPool because the orchestrator's self-stake is already accounted for by the `bondForWithHint()` call that the L2Migrator executes to add the self-stake for the orchestrator. The fix is to subtract the orchestrator's self-stake from its delegated stake in order to calculate its non-self delegated stake and to use that value when staking for the DelegatorPool.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
