### PR TITLE
test: Add duplicate unbonding lock id test for L2Migrator

### DIFF
--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -597,6 +597,16 @@ describe('L2Migrator', function() {
       await expect(tx).to.revertedWith(
           'L2Migrator#finalizeMigrateUnbondingLocks: ALREADY_MIGRATED',
       );
+
+      // None of the ids have been migrated previously, but the list contains duplicate ids
+      params.unbondingLockIds = [11, 11, 12];
+      tx = l2Migrator
+          .connect(mockL1MigratorL2AliasEOA)
+          .finalizeMigrateUnbondingLocks(params);
+
+      await expect(tx).to.revertedWith(
+          'L2Migrator#finalizeMigrateUnbondingLocks: ALREADY_MIGRATED',
+      );
     });
 
     it('finalizes migration', async () => {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds a test case demonstrating that if there are duplicate unbonding lock ids passed to `finalizeMigrateUnbondingLock()` the migration will be rejected because there is a require statement that will trigger a revert if any of the ids have already been migrated already. 

Related to https://github.com/code-423n4/2022-01-livepeer-findings/issues/89

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added a unit test case.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
