### PR TITLE
L2: Add GatewayRouter compatible outboundTransfer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
     'require-jsdoc': 'off',
     'camelcase': 'off',
     'new-cap': ['error', {capIsNew: false}],
+    'no-unexpected-multiline': 'off'
   },
 };

--- a/contracts/L2/gateway/L2LPTGateway.sol
+++ b/contracts/L2/gateway/L2LPTGateway.sol
@@ -57,7 +57,26 @@ contract L2LPTGateway is IL2LPTGateway, ControlledGateway, L2ArbitrumMessenger {
      * The tokens will be received on L1 only after the wait period (7 days) is over
      * @dev no additional callhook data is allowed
      * @param _l1Token L1 Address of LPT
-     * @param _to Recepient address on L1
+     * @param _to Recipient address on L1
+     * @param _amount Amount of tokens to burn
+     * @param _data Contains sender and additional data to send to L1
+     * @return ID of the withdraw tx
+     */
+    function outboundTransfer(
+        address _l1Token,
+        address _to,
+        uint256 _amount,
+        bytes calldata _data
+    ) external override returns (bytes memory) {
+        return outboundTransfer(_l1Token, _to, _amount, 0, 0, _data);
+    }
+
+    /**
+     * @notice Burns L2 tokens and sends a message to L1
+     * The tokens will be received on L1 only after the wait period (7 days) is over
+     * @dev no additional callhook data is allowed
+     * @param _l1Token L1 Address of LPT
+     * @param _to Recipient address on L1
      * @param _amount Amount of tokens to burn
      * @param _data Contains sender and additional data to send to L1
      * @return res ID of the withdraw tx
@@ -66,8 +85,10 @@ contract L2LPTGateway is IL2LPTGateway, ControlledGateway, L2ArbitrumMessenger {
         address _l1Token,
         address _to,
         uint256 _amount,
+        uint256, // maxGas
+        uint256, // gasPriceBid
         bytes calldata _data
-    ) public override whenNotPaused returns (bytes memory res) {
+    ) public whenNotPaused returns (bytes memory res) {
         require(_l1Token == l1Lpt, "TOKEN_NOT_LPT");
 
         (address from, bytes memory extraData) = parseOutboundData(_data);

--- a/test/unit/L2/l2LPTGateway.test.ts
+++ b/test/unit/L2/l2LPTGateway.test.ts
@@ -349,7 +349,7 @@ describe('L2 Gateway', function() {
 
       it('should fail to tranfer', async () => {
         await expect(
-            l2Gateway.outboundTransfer(
+            l2Gateway['outboundTransfer(address,address,uint256,bytes)'](
                 mockL1LptEOA.address,
                 sender.address,
                 withdrawAmount,
@@ -361,7 +361,7 @@ describe('L2 Gateway', function() {
 
     describe('when gateway is not paused', async function() {
       it('should revert when called with a different token', async () => {
-        const tx = l2Gateway.outboundTransfer(
+        const tx = l2Gateway['outboundTransfer(address,address,uint256,bytes)'](
             token.address,
             sender.address,
             withdrawAmount,
@@ -373,7 +373,7 @@ describe('L2 Gateway', function() {
       it('should revert when allowance is insufficient', async () => {
         const tx = l2Gateway
             .connect(sender)
-            .outboundTransfer(
+            ['outboundTransfer(address,address,uint256,bytes)'](
                 mockL1LptEOA.address,
                 sender.address,
                 initialTotalL2Supply,
@@ -391,7 +391,7 @@ describe('L2 Gateway', function() {
 
         const tx = l2Gateway
             .connect(sender)
-            .outboundTransfer(
+            ['outboundTransfer(address,address,uint256,bytes)'](
                 mockL1LptEOA.address,
                 sender.address,
                 initialTotalL2Supply + 100,
@@ -403,7 +403,7 @@ describe('L2 Gateway', function() {
       });
 
       it('should revert when called with callHookData', async () => {
-        const tx = l2Gateway.outboundTransfer(
+        const tx = l2Gateway['outboundTransfer(address,address,uint256,bytes)'](
             mockL1LptEOA.address,
             sender.address,
             withdrawAmount,
@@ -416,7 +416,7 @@ describe('L2 Gateway', function() {
         // remove burn permissions
         await token.revokeRole(BURNER_ROLE, l2Gateway.address);
 
-        const tx = l2Gateway.outboundTransfer(
+        const tx = l2Gateway['outboundTransfer(address,address,uint256,bytes)'](
             mockL1LptEOA.address,
             sender.address,
             withdrawAmount,
@@ -433,7 +433,7 @@ describe('L2 Gateway', function() {
         await token.connect(sender).approve(l2Gateway.address, withdrawAmount);
         const tx = await l2Gateway
             .connect(sender)
-            .outboundTransfer(
+            ['outboundTransfer(address,address,uint256,bytes)'](
                 mockL1LptEOA.address,
                 sender.address,
                 withdrawAmount,
@@ -479,7 +479,7 @@ describe('L2 Gateway', function() {
         await token.connect(sender).approve(l2Gateway.address, withdrawAmount);
         const tx = await l2Gateway
             .connect(sender)
-            .outboundTransfer(
+            ['outboundTransfer(address,address,uint256,bytes)'](
                 mockL1LptEOA.address,
                 receiver.address,
                 withdrawAmount,
@@ -530,12 +530,15 @@ describe('L2 Gateway', function() {
         );
 
         await token.connect(sender).approve(l2Gateway.address, withdrawAmount);
+        // Router calls outboundTransfer() with two additional uint256 params that are unused and set to 0
         const tx = await l2Gateway
             .connect(mockL2RouterEOA)
-            .outboundTransfer(
+            ['outboundTransfer(address,address,uint256,uint256,uint256,bytes)'](
                 mockL1LptEOA.address,
                 receiver.address,
                 withdrawAmount,
+                0,
+                0,
                 routerEncodedData,
             );
 
@@ -579,7 +582,7 @@ describe('L2 Gateway', function() {
         await token.connect(sender).approve(l2Gateway.address, withdrawAmount);
         await l2Gateway
             .connect(sender)
-            .outboundTransfer(
+            ['outboundTransfer(address,address,uint256,bytes)'](
                 mockL1LptEOA.address,
                 sender.address,
                 withdrawAmount,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates the `outboundTransfer()` function in L2LPTGateway to accept two unused params. These params are present in the `outboundTransfer()` function signature expected by the Arbitrum L2GatewayRouter and they are expected to be unused so the L2GatewayRouter always sets the values of these two params to 0.

We follow a similar pattern to the [L2DaiGateway](https://github.com/makerdao/arbitrum-dai-bridge/blob/ba5e98631307025a74fc03108492b20af57a0d3a/contracts/l2/L2DaiGateway.sol#L79) where there are two versions of `outboundTransfer()` - a public L2GatewayRouter compatible function and an external function that excludes the two unused params with the latter calling the former.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

https://github.com/code-423n4/2022-01-livepeer-findings/issues/202

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
