### PR TITLE
L2: Use l2Addr for orchestrator when finalizing migration

### DIFF
--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -143,7 +143,7 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator, AccessControl {
             // 1. Stake _params.stake on behalf of _params.l2Addr
             // 2. Create delegator pool
             // 3. Stake non-self delegated stake on behalf of the delegator pool
-            bondFor(_params.stake, _params.l2Addr, _params.delegate);
+            bondFor(_params.stake, _params.l2Addr, _params.l2Addr);
 
             address poolAddr = Clones.clone(delegatorPoolImpl);
 
@@ -156,7 +156,7 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator, AccessControl {
             bondFor(
                 nonSelfDelegatedStake - claimedDelegatedStake[_params.l1Addr],
                 poolAddr,
-                _params.delegate
+                _params.l2Addr
             );
 
             IDelegatorPool(poolAddr).initialize(bondingManagerAddr);

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -311,20 +311,25 @@ describe('L2Migrator', function() {
 
           expect(await deployed.migrator()).to.equal(l2Migrator.address);
 
+          // Check for case where the orchestrator's L2 address is different from its delegate address (which is its L1 address)
+          expect(params.delegate).to.not.be.equal(params.l2Addr);
+
+          // Make sure that the orchestrator is staked to it's L2 address and NOT its delegate/L1 address
           expect(bondingManagerMock.bondForWithHint.atCall(0)).to.be.calledWith(
               params.stake,
               params.l2Addr,
-              params.delegate,
+              params.l2Addr,
               ethers.constants.AddressZero,
               ethers.constants.AddressZero,
               ethers.constants.AddressZero,
               ethers.constants.AddressZero,
           );
 
+          // Make sure that the delegator pool is staked to the orchestrator's L2 address and NOT its delegate/L1 address
           expect(bondingManagerMock.bondForWithHint.atCall(1)).to.be.calledWith(
               params.delegatedStake - params.stake,
               delegatorPool,
-              params.delegate,
+              params.l2Addr,
               ethers.constants.AddressZero,
               ethers.constants.AddressZero,
               ethers.constants.AddressZero,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes an issue when finalizing a migration for an orchestrator in `finalizeMigrateDelegator()` that could cause the wrong address to be used as the delegate for staking actions.

Previously, if the migrating address is an orchestrator on L1, `params.delegate` would be the delegate for the address' self-stake and its non-self delegated stake via a newly created delegator pool. In the scenario where `params.l2Addr` is different than `params.l1Addr`, the migrating address would end up being staked to its L1 address despite wishing to be staked to its L2 address. This means that the address wouldn't immediately be considered an orchestrator by the BondingManager because the migrating address would not be staked to itself. Additionally, the newly created delegator pool would also end up being staked to the orchestrator's L1 address instead of the orchestrator's L2 address. 

Note: If the above scenario occurred, an orchestrator could recover by changing its stake delegation on L2. However, all delegators from L1 would need to claim their stake from the delegator pool before changing their stake delegation on L2.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
