### PR TITLE
L2: Set msg.value for fundDepositAndReserveFor

### DIFF
--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -24,7 +24,7 @@ interface ITicketBroker {
         address _addr,
         uint256 _depositAmount,
         uint256 _reserveAmount
-    ) external;
+    ) external payable;
 }
 
 interface IMerkleSnapshot {
@@ -223,11 +223,10 @@ contract L2Migrator is L2ArbitrumMessenger, IMigrator, AccessControl {
 
         migratedSenders[_params.l1Addr] = true;
 
-        ITicketBroker(ticketBrokerAddr).fundDepositAndReserveFor(
-            _params.l2Addr,
-            _params.deposit,
-            _params.reserve
-        );
+        // msg.value for this call must be equal to deposit + reserve amounts
+        ITicketBroker(ticketBrokerAddr).fundDepositAndReserveFor{
+            value: _params.deposit + _params.reserve
+        }(_params.l2Addr, _params.deposit, _params.reserve);
 
         emit MigrateSenderFinalized(_params);
     }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Sets msg.value in the L2Migrator `fundDepositAndReserveFor()` call on the TicketBroker - the value needs to be equal to the deposit and reserve amounts [1].

[1] https://github.com/livepeer/protocol/blob/0a680e3cf570fcde9ef6165bb3b1a42f7f58bef2/contracts/pm/mixins/MixinTicketBrokerCore.sol#L91

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added test cases making sure msg.value is set properly and that the balance updates occur after a `finalizeMigrateSender()` call.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
