### PR TITLE
Fetch BondingManager, TicketBroker and MerkleSnapshot from controller

### DIFF
--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -57,7 +57,7 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
 
     event L1MigratorUpdate(address _l1MigratorAddr);
 
-    event ProtocolContractUpdate(bytes32 _id, address _address);
+    event ControllerContractUpdate(bytes32 id, address addr);
 
     event MigrateDelegatorFinalized(MigrateDelegatorParams params);
 
@@ -331,7 +331,10 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
 
         if (_bondingManagerAddr != bondingManagerAddr) {
             bondingManagerAddr = _bondingManagerAddr;
-            emit ProtocolContractUpdate(bondingManagerId, _bondingManagerAddr);
+            emit ControllerContractUpdate(
+                bondingManagerId,
+                _bondingManagerAddr
+            );
         }
 
         // Check and update TicketBroker address
@@ -340,7 +343,7 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
 
         if (_ticketBrokerAddr != ticketBrokerAddr) {
             ticketBrokerAddr = _ticketBrokerAddr;
-            emit ProtocolContractUpdate(ticketBrokerId, _ticketBrokerAddr);
+            emit ControllerContractUpdate(ticketBrokerId, _ticketBrokerAddr);
         }
 
         // Check and update MerkleSnapshot address
@@ -349,7 +352,10 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
 
         if (_merkleSnapshotAddr != merkleSnapshotAddr) {
             merkleSnapshotAddr = _merkleSnapshotAddr;
-            emit ProtocolContractUpdate(merkleSnapshotId, _merkleSnapshotAddr);
+            emit ControllerContractUpdate(
+                merkleSnapshotId,
+                _merkleSnapshotAddr
+            );
         }
     }
 }

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -223,6 +223,23 @@ describe('L2Migrator', function() {
         await expect(tx)
             .to.emit(l2Migrator, 'ControllerContractUpdate')
             .withArgs(bondingManagerID, ethers.constants.AddressZero);
+
+        // confirm only a single event was emitted
+        const events = await l2Migrator.queryFilter(
+            l2Migrator.filters.ControllerContractUpdate(),
+            'latest',
+        );
+        expect(events.length).to.equal(1);
+
+        expect(await l2Migrator.bondingManagerAddr()).to.equal(
+            ethers.constants.AddressZero,
+        );
+        expect(await l2Migrator.ticketBrokerAddr()).to.equal(
+            mockTicketBrokerEOA.address,
+        );
+        expect(await l2Migrator.merkleSnapshotAddr()).to.equal(
+            mockMerkleSnapshotEOA.address,
+        );
       });
     });
 
@@ -236,6 +253,23 @@ describe('L2Migrator', function() {
         await expect(tx)
             .to.emit(l2Migrator, 'ControllerContractUpdate')
             .withArgs(ticketBrokerID, ethers.constants.AddressZero);
+
+        // confirm only a single event was emitted
+        const events = await l2Migrator.queryFilter(
+            l2Migrator.filters.ControllerContractUpdate(),
+            'latest',
+        );
+        expect(events.length).to.equal(1);
+
+        expect(await l2Migrator.bondingManagerAddr()).to.equal(
+            mockBondingManagerEOA.address,
+        );
+        expect(await l2Migrator.ticketBrokerAddr()).to.equal(
+            ethers.constants.AddressZero,
+        );
+        expect(await l2Migrator.merkleSnapshotAddr()).to.equal(
+            mockMerkleSnapshotEOA.address,
+        );
       });
     });
 
@@ -249,6 +283,23 @@ describe('L2Migrator', function() {
         await expect(tx)
             .to.emit(l2Migrator, 'ControllerContractUpdate')
             .withArgs(merkleSnapshotID, ethers.constants.AddressZero);
+
+        // confirm only a single event was emitted
+        const events = await l2Migrator.queryFilter(
+            l2Migrator.filters.ControllerContractUpdate(),
+            'latest',
+        );
+        expect(events.length).to.equal(1);
+
+        expect(await l2Migrator.bondingManagerAddr()).to.equal(
+            mockBondingManagerEOA.address,
+        );
+        expect(await l2Migrator.ticketBrokerAddr()).to.equal(
+            mockTicketBrokerEOA.address,
+        );
+        expect(await l2Migrator.merkleSnapshotAddr()).to.equal(
+            ethers.constants.AddressZero,
+        );
       });
     });
 
@@ -267,6 +318,7 @@ describe('L2Migrator', function() {
             .returns(ethers.constants.AddressZero);
 
         const tx = await l2Migrator.syncControllerContracts();
+
         await expect(tx)
             .to.emit(l2Migrator, 'ControllerContractUpdate')
             .withArgs(bondingManagerID, ethers.constants.AddressZero);
@@ -276,6 +328,23 @@ describe('L2Migrator', function() {
         await expect(tx)
             .to.emit(l2Migrator, 'ControllerContractUpdate')
             .withArgs(merkleSnapshotID, ethers.constants.AddressZero);
+
+        // confirm three events were emitted
+        const events = await l2Migrator.queryFilter(
+            l2Migrator.filters.ControllerContractUpdate(),
+            'latest',
+        );
+        expect(events.length).to.equal(3);
+
+        expect(await l2Migrator.bondingManagerAddr()).to.equal(
+            ethers.constants.AddressZero,
+        );
+        expect(await l2Migrator.ticketBrokerAddr()).to.equal(
+            ethers.constants.AddressZero,
+        );
+        expect(await l2Migrator.merkleSnapshotAddr()).to.equal(
+            ethers.constants.AddressZero,
+        );
       });
     });
   });

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -208,11 +208,11 @@ describe('L2Migrator', function() {
     describe('addresses do not change', () => {
       it('should set addresses', async () => {
         const tx = l2Migrator.syncControllerContracts();
-        await expect(tx).to.not.emit(l2Migrator, 'ProtocolContractUpdate');
+        await expect(tx).to.not.emit(l2Migrator, 'ControllerContractUpdate');
       });
     });
 
-    describe('only bondingManager Changes', () => {
+    describe('only bondingManager changes', () => {
       it('should set addresses', async () => {
         controllerMock.getContract
             .whenCalledWith(bondingManagerID)
@@ -221,12 +221,12 @@ describe('L2Migrator', function() {
         const tx = await l2Migrator.syncControllerContracts();
 
         await expect(tx)
-            .to.emit(l2Migrator, 'ProtocolContractUpdate')
+            .to.emit(l2Migrator, 'ControllerContractUpdate')
             .withArgs(bondingManagerID, ethers.constants.AddressZero);
       });
     });
 
-    describe('only ticketBroker Changes', () => {
+    describe('only ticketBroker changes', () => {
       it('should set addresses', async () => {
         controllerMock.getContract
             .whenCalledWith(ticketBrokerID)
@@ -234,12 +234,12 @@ describe('L2Migrator', function() {
 
         const tx = await l2Migrator.syncControllerContracts();
         await expect(tx)
-            .to.emit(l2Migrator, 'ProtocolContractUpdate')
+            .to.emit(l2Migrator, 'ControllerContractUpdate')
             .withArgs(ticketBrokerID, ethers.constants.AddressZero);
       });
     });
 
-    describe('only merkleSnapshot Changes', () => {
+    describe('only merkleSnapshot changes', () => {
       it('should set addresses', async () => {
         controllerMock.getContract
             .whenCalledWith(merkleSnapshotID)
@@ -247,7 +247,7 @@ describe('L2Migrator', function() {
 
         const tx = await l2Migrator.syncControllerContracts();
         await expect(tx)
-            .to.emit(l2Migrator, 'ProtocolContractUpdate')
+            .to.emit(l2Migrator, 'ControllerContractUpdate')
             .withArgs(merkleSnapshotID, ethers.constants.AddressZero);
       });
     });
@@ -268,13 +268,13 @@ describe('L2Migrator', function() {
 
         const tx = await l2Migrator.syncControllerContracts();
         await expect(tx)
-            .to.emit(l2Migrator, 'ProtocolContractUpdate')
+            .to.emit(l2Migrator, 'ControllerContractUpdate')
             .withArgs(bondingManagerID, ethers.constants.AddressZero);
         await expect(tx)
-            .to.emit(l2Migrator, 'ProtocolContractUpdate')
+            .to.emit(l2Migrator, 'ControllerContractUpdate')
             .withArgs(ticketBrokerID, ethers.constants.AddressZero);
         await expect(tx)
-            .to.emit(l2Migrator, 'ProtocolContractUpdate')
+            .to.emit(l2Migrator, 'ControllerContractUpdate')
             .withArgs(merkleSnapshotID, ethers.constants.AddressZero);
       });
     });


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Adds `syncControllerContracts` function to fetch addresses of BondingManager, TicketBroker and MerkleSnapshot from the controller and save them in the state in case any of these contracts change.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- added `syncControllerContracts`
- updated tests

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
ran tests

**Does this pull request close any open issues?**
<!-- Fixes # -->
closes #65

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
