### PR TITLE
renamed l1Migrator variable to l1MigratorAddr for consistency

### DIFF
--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -45,7 +45,7 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
     address public ticketBrokerAddr;
     address public merkleSnapshotAddr;
 
-    address public l1Migrator;
+    address public l1MigratorAddr;
     address public delegatorPoolImpl;
     bool public claimStakeEnabled;
 
@@ -55,7 +55,7 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
     mapping(address => mapping(uint256 => bool)) public migratedUnbondingLocks;
     mapping(address => bool) public migratedSenders;
 
-    event L1MigratorUpdate(address _l1Migrator);
+    event L1MigratorUpdate(address _l1MigratorAddr);
 
     event MigrateDelegatorFinalized(MigrateDelegatorParams params);
 
@@ -85,13 +85,13 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
     constructor(address _controller) Manager(_controller) {}
 
     function initialize(
-        address _l1Migrator,
+        address _l1MigratorAddr,
         address _delegatorPoolImpl,
         address _bondingManagerAddr,
         address _ticketBrokerAddr,
         address _merkleSnapshotAddr
     ) external onlyControllerOwner {
-        l1Migrator = _l1Migrator;
+        l1MigratorAddr = _l1MigratorAddr;
         delegatorPoolImpl = _delegatorPoolImpl;
         bondingManagerAddr = _bondingManagerAddr;
         ticketBrokerAddr = _ticketBrokerAddr;
@@ -100,11 +100,14 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
 
     /**
      * @notice Sets L1Migrator
-     * @param _l1Migrator L1Migrator address
+     * @param _l1MigratorAddr L1Migrator address
      */
-    function setL1Migrator(address _l1Migrator) external onlyControllerOwner {
-        l1Migrator = _l1Migrator;
-        emit L1MigratorUpdate(_l1Migrator);
+    function setL1Migrator(address _l1MigratorAddr)
+        external
+        onlyControllerOwner
+    {
+        l1MigratorAddr = _l1MigratorAddr;
+        emit L1MigratorUpdate(_l1MigratorAddr);
     }
 
     /**
@@ -134,7 +137,7 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
      */
     function finalizeMigrateDelegator(MigrateDelegatorParams calldata _params)
         external
-        onlyL1Counterpart(l1Migrator)
+        onlyL1Counterpart(l1MigratorAddr)
     {
         require(
             !migratedDelegators[_params.l1Addr],
@@ -202,7 +205,7 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
      */
     function finalizeMigrateUnbondingLocks(
         MigrateUnbondingLocksParams calldata _params
-    ) external onlyL1Counterpart(l1Migrator) {
+    ) external onlyL1Counterpart(l1MigratorAddr) {
         uint256 unbondingLockIdsLen = _params.unbondingLockIds.length;
         for (uint256 i; i < unbondingLockIdsLen; i++) {
             uint256 id = _params.unbondingLockIds[i];
@@ -224,7 +227,7 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
      */
     function finalizeMigrateSender(MigrateSenderParams calldata _params)
         external
-        onlyL1Counterpart(l1Migrator)
+        onlyL1Counterpart(l1MigratorAddr)
     {
         require(!migratedSenders[_params.l1Addr], "SENDER_ALREADY_MIGRATED");
 

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -138,7 +138,7 @@ describe('L2Migrator', function() {
 
   describe('initializer', () => {
     it('sets addresses', async () => {
-      const l1MigratorAddr = await l2Migrator.l1Migrator();
+      const l1MigratorAddr = await l2Migrator.l1MigratorAddr();
       expect(l1MigratorAddr).to.equal(mockL1MigratorEOA.address);
       const delegatorPoolImpl = await l2Migrator.delegatorPoolImpl();
       expect(delegatorPoolImpl).to.equal(delegatorPool.address);
@@ -167,7 +167,7 @@ describe('L2Migrator', function() {
             .connect(admin)
             .initialize(addr, addr, addr, addr, addr);
 
-        const l1MigratorAddr = await l2Migrator.l1Migrator();
+        const l1MigratorAddr = await l2Migrator.l1MigratorAddr();
         expect(l1MigratorAddr).to.equal(addr);
         const delegatorPoolImpl = await l2Migrator.delegatorPoolImpl();
         expect(delegatorPoolImpl).to.equal(addr);
@@ -199,7 +199,7 @@ describe('L2Migrator', function() {
         await expect(tx)
             .to.emit(l2Migrator, 'L1MigratorUpdate')
             .withArgs(notL1MigratorEOA.address);
-        const l1MigratorAddr = await l2Migrator.l1Migrator();
+        const l1MigratorAddr = await l2Migrator.l1MigratorAddr();
         expect(l1MigratorAddr).to.equal(notL1MigratorEOA.address);
       });
     });


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Fixes mismatch between the variable naming pattern in the Migrator counterparts for storing each other's reference.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- updated L1Migrator reference variable variable name in L2 Migrator

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
ran tests

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
