### PR TITLE
L2: Handle null delegate in claimStake

### DIFF
--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -276,20 +276,23 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
         );
 
         migratedDelegators[delegator] = true;
-        claimedDelegatedStake[_delegate] += _stake;
 
-        address pool = delegatorPools[_delegate];
+        if (_delegate != address(0)) {
+            claimedDelegatedStake[_delegate] += _stake;
 
-        address delegate = _delegate;
-        if (_newDelegate != address(0)) {
-            delegate = _newDelegate;
-        }
+            address pool = delegatorPools[_delegate];
 
-        if (pool != address(0)) {
-            // Claim stake that is held by the delegator pool
-            IDelegatorPool(pool).claim(delegator, _stake);
-        } else {
-            bondFor(_stake, delegator, delegate);
+            address delegate = _delegate;
+            if (_newDelegate != address(0)) {
+                delegate = _newDelegate;
+            }
+
+            if (pool != address(0)) {
+                // Claim stake that is held by the delegator pool
+                IDelegatorPool(pool).claim(delegator, _stake);
+            } else {
+                bondFor(_stake, delegator, delegate);
+            }
         }
 
         // Only EOAs are included in the snapshot so we do not need to worry about
@@ -298,7 +301,7 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
             payable(delegator).transfer(_fees);
         }
 
-        emit StakeClaimed(delegator, delegate, _stake, _fees);
+        emit StakeClaimed(delegator, _delegate, _stake, _fees);
     }
 
     function bondFor(


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Add a null delegate check in `claimStake()` to skip staking logic if the delegator does not have a delegate in the L1 snapshot. Skipping the staking logic (i.e. claiming from an existing delegator pool or staking in the BondingManager) saves some gas in this scenario. This scenario is important to handle because a delegator can fully unbond on L1, but still have fees available to withdraw that it should be able to access on L2 when calling `claimStake()`.

If you run the following query at https://thegraph.com/hosted-service/subgraph/livepeer/livepeer

```
{
  delegators(where: { bondedAmount: "0", fees_not: "0" }) {
    id
    bondedAmount,
    fees
  }
}
```

you can see the delegators that have fully unbonded on L1, but have non-zero fees available for withdrawal.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
