### PR TITLE
L2: Add approve in L2Migrator

### DIFF
--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -40,10 +40,15 @@ interface IDelegatorPool {
     function claim(address _addr, uint256 _stake) external;
 }
 
+interface ApproveLike {
+    function approve(address _addr, uint256 _amount) external;
+}
+
 contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
     address public bondingManagerAddr;
     address public ticketBrokerAddr;
     address public merkleSnapshotAddr;
+    address public tokenAddr;
 
     address public l1MigratorAddr;
     address public delegatorPoolImpl;
@@ -312,6 +317,7 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
     ) private {
         IBondingManager bondingManager = IBondingManager(bondingManagerAddr);
 
+        ApproveLike(tokenAddr).approve(address(bondingManager), _amount);
         bondingManager.bondForWithHint(
             _amount,
             _owner,
@@ -359,6 +365,15 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
                 merkleSnapshotId,
                 _merkleSnapshotAddr
             );
+        }
+
+        // Check and update LivepeerToken address
+        bytes32 tokenId = keccak256("LivepeerToken");
+        address _tokenAddr = controller.getContract(tokenId);
+
+        if (_tokenAddr != tokenAddr) {
+            tokenAddr = _tokenAddr;
+            emit ControllerContractUpdate(tokenId, _tokenAddr);
         }
     }
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Cherry picked 1219992485aa09c00a12797948834421c18a6caa from https://github.com/livepeer/arbitrum-lpt-bridge/pull/49 which includes a fix that was already included in the testnet L2Migrator deployment for adding a missing approve() call before bondForWithHint(). Also, fetches the token address using the Controller.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
