### PR TITLE
Added script to verify claimed stake and fees

### DIFF
--- a/scripts/verify-claimed-stake-fees.ts
+++ b/scripts/verify-claimed-stake-fees.ts
@@ -82,23 +82,28 @@ const getClaimers = async () => {
   await Promise.all(
       events.map(async (event) => {
         const poolAddr = await l2Migrator.delegatorPools(event.args.delegate);
-        const delegatorPool: DelegatorPool = await ethers.getContractAt(
-            'DelegatorPool',
-            poolAddr,
-        );
 
-        const claimEvent = await delegatorPool.queryFilter(
-            delegatorPool.filters.Claimed(),
-            event.blockHash,
-        );
+        // if delegator pool does not exist
+        // i.e orchestrator did not migrate
+        if (poolAddr !== ethers.constants.AddressZero) {
+          const delegatorPool: DelegatorPool = await ethers.getContractAt(
+              'DelegatorPool',
+              poolAddr,
+          );
 
-        data.push({
-          address: event.args.delegator,
-          requestedStake: event.args.stake,
-          requestedFees: event.args.fees,
-          owedStake: claimEvent[0].args._stake,
-          owedFees: claimEvent[0].args._fees,
-        });
+          const claimEvent = await delegatorPool.queryFilter(
+              delegatorPool.filters.Claimed(),
+              event.blockHash,
+          );
+
+          data.push({
+            address: event.args.delegator,
+            requestedStake: event.args.stake,
+            requestedFees: event.args.fees,
+            owedStake: claimEvent[0].args._stake,
+            owedFees: claimEvent[0].args._fees,
+          });
+        }
       }),
   );
 

--- a/scripts/verify-claimed-stake-fees.ts
+++ b/scripts/verify-claimed-stake-fees.ts
@@ -1,0 +1,83 @@
+import {ethers} from 'hardhat';
+import hre from 'hardhat';
+import {EthersProviderWrapper} from '../deploy/ethers-provider-wrapper';
+import {L2Migrator} from '../typechain';
+
+const getL1PendingStake = async (orchAddr: string) => {
+  const bondingManagerAddr = '0x511bc4556d823ae99630ae8de28b9b80df90ea2e';
+  const bondingManagerABI = [
+    'function pendingStake(address _delegator, uint256 _endRound) public view returns (uint256)',
+    'function pendingFees(address _delegator, uint256 _endRound) public view returns (uint256)',
+  ];
+  const roundNum = 2466;
+
+  const bondingManager = new ethers.Contract(
+      bondingManagerAddr,
+      bondingManagerABI,
+      new EthersProviderWrapper(hre.companionNetworks['l1'].provider),
+  );
+
+  const pendingStake = await bondingManager.pendingStake(orchAddr, roundNum);
+  const pendingFees = await bondingManager.pendingFees(orchAddr, roundNum);
+
+  return {
+    address: orchAddr,
+    stake: pendingStake,
+    fees: pendingFees,
+  };
+};
+
+const getClaimers = async () => {
+  const l2MigratorAddr = (await hre.deployments.get('L2Migrator')).address;
+  const claimStakeEnableBlock = 14263154;
+
+  const l2Migrator: L2Migrator = await ethers.getContractAt(
+      'L2Migrator',
+      l2MigratorAddr,
+  );
+
+  const events = await l2Migrator.queryFilter(
+      l2Migrator.filters.StakeClaimed(),
+      claimStakeEnableBlock,
+      'latest',
+  );
+
+  return events.map((event) => {
+    return {
+      address: event.args.delegator,
+      stake: event.args.stake,
+      fees: event.args.fees,
+    };
+  });
+};
+
+async function main(): Promise<void> {
+  const stakeClaimers = await getClaimers();
+
+  const pendingStake = await Promise.all(
+      stakeClaimers.map((delegator) => getL1PendingStake(delegator.address)),
+  );
+
+  console.log(
+      `address \t L2 stake claimed \2 L1 pending stake \t L2 fees claimed \t L1 pending fees`,
+  );
+
+  stakeClaimers.forEach((claimer) => {
+    const l1Stake = pendingStake.filter(
+        (delegator) => delegator.address === claimer.address,
+    );
+    console.log(`
+        ${claimer.address} \t
+        ${ethers.utils.formatEther(claimer.stake)} \t
+        ${ethers.utils.formatEther(l1Stake[0].stake)} \t
+        ${ethers.utils.formatEther(claimer.fees)} \t
+        ${ethers.utils.formatEther(l1Stake[0].fees)}`);
+  });
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error: Error) => {
+      console.error(error);
+      process.exit(1);
+    });

--- a/scripts/verify-claimed-stake-fees.ts
+++ b/scripts/verify-claimed-stake-fees.ts
@@ -1,14 +1,16 @@
 import {ethers} from 'hardhat';
 import hre from 'hardhat';
 import {EthersProviderWrapper} from '../deploy/ethers-provider-wrapper';
-import {L2Migrator} from '../typechain';
+import {DelegatorPool, L2Migrator} from '../typechain';
+import {BigNumber} from 'ethers';
 
-const getL1PendingStake = async (orchAddr: string) => {
+const bondingManagerABI = [
+  'function pendingStake(address _delegator, uint256 _endRound) public view returns (uint256)',
+  'function pendingFees(address _delegator, uint256 _endRound) public view returns (uint256)',
+];
+
+const getL1Pending = async (orchAddr: string) => {
   const bondingManagerAddr = '0x511bc4556d823ae99630ae8de28b9b80df90ea2e';
-  const bondingManagerABI = [
-    'function pendingStake(address _delegator, uint256 _endRound) public view returns (uint256)',
-    'function pendingFees(address _delegator, uint256 _endRound) public view returns (uint256)',
-  ];
   const roundNum = 2466;
 
   const bondingManager = new ethers.Contract(
@@ -27,9 +29,29 @@ const getL1PendingStake = async (orchAddr: string) => {
   };
 };
 
+const getL2Pending = async (orchAddr: string) => {
+  const bondingManagerAddr = '0x35Bcf3c30594191d53231E4FF333E8A770453e40';
+  const roundNum = 2466; // does not matter on L2, only current round is used
+
+  const bondingManager = new ethers.Contract(
+      bondingManagerAddr,
+      bondingManagerABI,
+      new EthersProviderWrapper(hre.network.provider),
+  );
+
+  const pendingStake = await bondingManager.pendingStake(orchAddr, roundNum);
+  const pendingFees = await bondingManager.pendingFees(orchAddr, roundNum);
+
+  return {
+    address: orchAddr,
+    stake: pendingStake,
+    fees: pendingFees,
+  };
+};
+
 const getClaimers = async () => {
-  const l2MigratorAddr = (await hre.deployments.get('L2Migrator')).address;
-  const claimStakeEnableBlock = 14263154;
+  const l2MigratorAddr = (await hre.deployments.get('L2MigratorProxy')).address;
+  const claimStakeEnableBlock = 6737210;
 
   const l2Migrator: L2Migrator = await ethers.getContractAt(
       'L2Migrator',
@@ -42,37 +64,79 @@ const getClaimers = async () => {
       'latest',
   );
 
-  return events.map((event) => {
-    return {
+  console.log(events.length, 'delegators claimed stake and fees');
+
+  const data: {
+    address: string;
+    requestedStake: BigNumber;
+    requestedFees: BigNumber;
+    owedStake: BigNumber;
+    owedFees: BigNumber;
+  }[] = [];
+
+  for (let index = 0; index < events.length; index++) {
+    const event = events[index];
+
+    const poolAddr = await l2Migrator.delegatorPools(event.args.delegate);
+    const delegatorPool: DelegatorPool = await ethers.getContractAt(
+        'DelegatorPool',
+        poolAddr,
+    );
+
+    const claimEvent = await delegatorPool.queryFilter(
+        delegatorPool.filters.Claimed(),
+        event.blockHash,
+    );
+
+    data.push({
       address: event.args.delegator,
-      stake: event.args.stake,
-      fees: event.args.fees,
-    };
-  });
+      requestedStake: event.args.stake,
+      requestedFees: event.args.fees,
+      owedStake: claimEvent[0].args._stake,
+      owedFees: claimEvent[0].args._fees,
+    });
+  }
+
+  return data;
 };
 
 async function main(): Promise<void> {
+  console.log('fetching Delegators who called claimStake');
   const stakeClaimers = await getClaimers();
 
-  const pendingStake = await Promise.all(
-      stakeClaimers.map((delegator) => getL1PendingStake(delegator.address)),
+  console.log('fetching L1 pending stake and fees');
+  const pendingL1 = await Promise.all(
+      stakeClaimers.map((delegator) => getL1Pending(delegator.address)),
   );
 
-  console.log(
-      `address \t L2 stake claimed \2 L1 pending stake \t L2 fees claimed \t L1 pending fees`,
+  console.log('fetching L2 pending stake and fees');
+  const pendingL2 = await Promise.all(
+      stakeClaimers.map((delegator) => getL2Pending(delegator.address)),
   );
+
+  const table: any = [];
 
   stakeClaimers.forEach((claimer) => {
-    const l1Stake = pendingStake.filter(
+    const l1Pending = pendingL1.filter(
         (delegator) => delegator.address === claimer.address,
-    );
-    console.log(`
-        ${claimer.address} \t
-        ${ethers.utils.formatEther(claimer.stake)} \t
-        ${ethers.utils.formatEther(l1Stake[0].stake)} \t
-        ${ethers.utils.formatEther(claimer.fees)} \t
-        ${ethers.utils.formatEther(l1Stake[0].fees)}`);
+    )[0];
+
+    const l2Pending = pendingL2.filter(
+        (delegator) => delegator.address === claimer.address,
+    )[0];
+
+    table.push({
+      address: claimer.address,
+      l2pendingStake: ethers.utils.formatEther(l2Pending.stake),
+      l1pendingStake: ethers.utils.formatEther(l1Pending.stake),
+      owedStake: ethers.utils.formatEther(claimer.owedStake),
+      l2pendingFees: ethers.utils.formatEther(l2Pending.fees),
+      l1pendingFees: ethers.utils.formatEther(l1Pending.fees),
+      owedFees: ethers.utils.formatEther(claimer.owedFees),
+    });
   });
+
+  console.table(table);
 }
 
 main()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
created script to compare pending L1 and L2 stake with owedStake as well as pending L1 and L2 fees with owedFees when a delegator calls claimStake on L2 Migrator

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

run `npx hardhat run scripts/verify-claimed-stake-fees.ts --network arbitrumMainnet`

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] All tests using `yarn test` pass
