### PR TITLE
set up foundry environment and added simulation of L1<>L2 unbonding lock migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,8 @@ typechain
 #Hardhat files
 cache
 artifacts
+
+#foundry
+/.dapple
+/build
+/out

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/ds-test"]
+	path = lib/ds-test
+	url = https://github.com/dapphub/ds-test

--- a/README.md
+++ b/README.md
@@ -10,10 +10,20 @@ cd arbitrum-lpt-bridge
 yarn
 ```
 
-## Run Tests
+## Run hardhat tests
 
 ```
 yarn test
+```
+
+## Run foundry tests
+
+```
+yarn test:forge
+```
+Note: Tests that require to fork a network can be run with the ```--fork-url``` flag:
+```
+yarn test:forge -vvvv --fork-url https://alchemy_ARBITRUM_MAINNET_rpc_address
 ```
 
 ## Run Slither

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,10 @@
+[default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+remappings = [
+        'ds-test/=lib/ds-test/src/',
+        '@openzeppelin/=node_modules/@openzeppelin/',
+        ]
+
+# See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:unit": "npx hardhat test test/unit/*.*",
     "test:integration": "npx hardhat test test/integration/**",
     "test:gas": "REPORT_GAS=true npx hardhat test test/gas-report/*",
+    "test:forge": "forge test -v",
     "tsc": "tsc"
   },
   "repository": {

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,1 @@
+ds-test/=lib/ds-test/src/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,1 +1,0 @@
-ds-test/=lib/ds-test/src/

--- a/src/test/UnbondingLock.t.sol
+++ b/src/test/UnbondingLock.t.sol
@@ -1,0 +1,138 @@
+pragma solidity 0.8.9;
+
+import "ds-test/test.sol";
+import "../../contracts/L2/gateway/L2Migrator.sol";
+
+interface CheatCodes {
+    function roll(uint256) external;
+
+    function prank(address) external;
+
+    function deal(address who, uint256 newBalance) external;
+
+    function startPrank(address) external;
+
+    function stopPrank() external;
+}
+
+interface IBondingManagerOverride {
+    function bondForWithHint(
+        uint256 _amount,
+        address _owner,
+        address _to,
+        address _oldDelegateNewPosPrev,
+        address _oldDelegateNewPosNext,
+        address _newDelegateNewPosPrev,
+        address _newDelegateNewPosNext
+    ) external;
+
+    function getDelegator(address _addr)
+        external
+        view
+        returns (
+            uint256 bondedAmount,
+            uint256 fees,
+            address delegateAddress,
+            uint256 delegatedAmount,
+            uint256 startRound,
+            uint256 lastClaimRound,
+            uint256 nextUnbondingLockId
+        );
+
+    function getDelegatorUnbondingLock(address _addr, uint256 _unbondingLockId)
+        external
+        view
+        returns (uint256 amount, uint256 withdrawRound);
+}
+
+// forge test -v --fork-url https://alchemy_ARBITRUM_MAINNET_rpc_address
+contract UnbondingLockTest is L2ArbitrumMessenger, DSTest {
+    CheatCodes public constant CHEATS = CheatCodes(HEVM_ADDRESS);
+
+    address public constant L1_MIGRATOR_ADDRESS =
+        0x21146B872D3A95d2cF9afeD03eE5a783DaE9A89A;
+    L2Migrator public constant L2_MIGRATOR =
+        L2Migrator(payable(0x148D5b6B4df9530c7C76A810bd1Cdf69EC4c2085));
+    IBondingManagerOverride public constant BONDING_MANAGER =
+        IBondingManagerOverride(0x35Bcf3c30594191d53231E4FF333E8A770453e40);
+
+    address public constant L1_DELEGATE =
+        0xa20416801aC2eACf2372e825B4a90ef52490c2Bb;
+    address public constant DELEGATOR_WITH_NON_NULL_DELEGATE =
+        0x0070EdA17A3656D6568eC4C94FeF34A396D20613;
+    address public constant DELEGATOR_WITH_NULL_DELEGATE =
+        0x00ac9C5193660b1F69092Fb4B0f011521B67627f;
+
+    uint256 public constant TEST_BLOCK_NUMBER = 14366402;
+
+    function testSanityCheck() public {
+        assertTrue(true);
+    }
+
+    function testFinalizeMigrateUnbondingLocksDelegatorWithNullDelegate()
+        public
+    {
+        CHEATS.roll(TEST_BLOCK_NUMBER);
+        CHEATS.startPrank(applyL1ToL2Alias(L1_MIGRATOR_ADDRESS));
+        address delegateAddress = _migrateBondingLock(
+            DELEGATOR_WITH_NULL_DELEGATE,
+            address(0)
+        );
+        CHEATS.stopPrank();
+        assertTrue(delegateAddress == address(0));
+    }
+
+    function testDelegateTransferWithDelegatorWithNullDelegate() public {
+        CHEATS.roll(TEST_BLOCK_NUMBER);
+        CHEATS.startPrank(applyL1ToL2Alias(L1_MIGRATOR_ADDRESS));
+        address l2DelegateAlias = applyL1ToL2Alias(L1_DELEGATE);
+        address delegateAddress = _migrateBondingLock(
+            DELEGATOR_WITH_NULL_DELEGATE,
+            l2DelegateAlias
+        );
+        CHEATS.stopPrank();
+        assertTrue(delegateAddress == l2DelegateAlias);
+    }
+
+    function testDelegateTransferWithDelegatorWithNonNullDelegate() public {
+        CHEATS.roll(TEST_BLOCK_NUMBER);
+        CHEATS.startPrank(applyL1ToL2Alias(L1_MIGRATOR_ADDRESS));
+        address l2DelegateAlias = applyL1ToL2Alias(L1_DELEGATE);
+        address delegateAddress = _migrateBondingLock(
+            DELEGATOR_WITH_NON_NULL_DELEGATE,
+            l2DelegateAlias
+        );
+        CHEATS.stopPrank();
+        assertTrue(delegateAddress == l2DelegateAlias);
+    }
+
+    function _migrateBondingLock(address _delegator, address _delegate)
+        private
+        returns (address)
+    {
+        uint256[] memory _unbondingLockIds = new uint256[](0);
+        IMigrator.MigrateUnbondingLocksParams
+            memory migrateDelegatorParams = IMigrator
+                .MigrateUnbondingLocksParams({
+                    l1Addr: _delegator,
+                    l2Addr: applyL1ToL2Alias(_delegator),
+                    total: 10,
+                    unbondingLockIds: _unbondingLockIds,
+                    delegate: _delegate
+                });
+        L2_MIGRATOR.finalizeMigrateUnbondingLocks(migrateDelegatorParams);
+
+        return _fetchDelegateAddress(_delegator);
+    }
+
+    function _fetchDelegateAddress(address _delegator)
+        private
+        view
+        returns (address)
+    {
+        (, , address delegateAddress, , , , ) = BONDING_MANAGER.getDelegator(
+            applyL1ToL2Alias(_delegator)
+        );
+        return delegateAddress;
+    }
+}

--- a/src/test/UnbondingLock.t.sol
+++ b/src/test/UnbondingLock.t.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.9;
 import "ds-test/test.sol";
 import "../../contracts/L2/gateway/L2Migrator.sol";
 import "./interfaces/ICheatCodes.sol";
-import "./interfaces/ICheatCodes.sol";
 import "./interfaces/IRoundManager.sol";
 import "./interfaces/IBondingManager.sol";
 
@@ -47,26 +46,24 @@ contract UnbondingLockTest is L2ArbitrumMessenger, DSTest {
         CHEATS.roll(TEST_BLOCK_NUMBER);
         ROUND_MANAGER.initializeRound();
         CHEATS.startPrank(applyL1ToL2Alias(L1_MIGRATOR_ADDRESS));
-        address l2DelegateAlias = applyL1ToL2Alias(L1_DELEGATE);
         address delegateAddress = _migrateBondingLock(
             DELEGATOR_WITH_NULL_DELEGATE,
-            l2DelegateAlias
+            L1_DELEGATE
         );
         CHEATS.stopPrank();
-        assertTrue(delegateAddress == l2DelegateAlias);
+        assertTrue(delegateAddress == L1_DELEGATE);
     }
 
     function testDelegateTransferWithDelegatorWithNonNullDelegate() public {
         CHEATS.roll(TEST_BLOCK_NUMBER);
         ROUND_MANAGER.initializeRound();
         CHEATS.startPrank(applyL1ToL2Alias(L1_MIGRATOR_ADDRESS));
-        address l2DelegateAlias = applyL1ToL2Alias(L1_DELEGATE);
         address delegateAddress = _migrateBondingLock(
             DELEGATOR_WITH_NON_NULL_DELEGATE,
-            l2DelegateAlias
+            L1_DELEGATE
         );
         CHEATS.stopPrank();
-        assertTrue(delegateAddress == l2DelegateAlias);
+        assertTrue(delegateAddress == L1_DELEGATE);
     }
 
     function _migrateBondingLock(address _delegator, address _delegate)
@@ -78,7 +75,7 @@ contract UnbondingLockTest is L2ArbitrumMessenger, DSTest {
             memory migrateDelegatorParams = IMigrator
                 .MigrateUnbondingLocksParams({
                     l1Addr: _delegator,
-                    l2Addr: applyL1ToL2Alias(_delegator),
+                    l2Addr: _delegator,
                     total: 10,
                     unbondingLockIds: _unbondingLockIds,
                     delegate: _delegate
@@ -94,7 +91,7 @@ contract UnbondingLockTest is L2ArbitrumMessenger, DSTest {
         returns (address)
     {
         (, , address delegateAddress, , , , ) = BONDING_MANAGER.getDelegator(
-            applyL1ToL2Alias(_delegator)
+            _delegator
         );
         return delegateAddress;
     }

--- a/src/test/interfaces/IBondingManager.sol
+++ b/src/test/interfaces/IBondingManager.sol
@@ -1,0 +1,31 @@
+pragma solidity 0.8.9;
+
+interface IBondingManagerOverride {
+    function bondForWithHint(
+        uint256 _amount,
+        address _owner,
+        address _to,
+        address _oldDelegateNewPosPrev,
+        address _oldDelegateNewPosNext,
+        address _newDelegateNewPosPrev,
+        address _newDelegateNewPosNext
+    ) external;
+
+    function getDelegator(address _addr)
+        external
+        view
+        returns (
+            uint256 bondedAmount,
+            uint256 fees,
+            address delegateAddress,
+            uint256 delegatedAmount,
+            uint256 startRound,
+            uint256 lastClaimRound,
+            uint256 nextUnbondingLockId
+        );
+
+    function getDelegatorUnbondingLock(address _addr, uint256 _unbondingLockId)
+        external
+        view
+        returns (uint256 amount, uint256 withdrawRound);
+}

--- a/src/test/interfaces/ICheatCodes.sol
+++ b/src/test/interfaces/ICheatCodes.sol
@@ -1,0 +1,14 @@
+pragma solidity 0.8.9;
+
+interface ICheatCodes {
+    function roll(uint256) external;
+
+    function prank(address) external;
+
+    function deal(address who, uint256 newBalance) external;
+
+    function startPrank(address) external;
+
+    function stopPrank() external;
+}
+

--- a/src/test/interfaces/IRoundManager.sol
+++ b/src/test/interfaces/IRoundManager.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.8.9;
+
+interface IRoundsManager {
+    function initializeRound() external;
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
- Adds the dapptools dependency (ds-test) under ```lib/ds-test``` and set up a foundry environment
- Simulates the unbonding lock simulation workflow on L2 with two different actors: a delegator with a null delegate on L1 and a delegator with a non-null delegate on L1

**Specific updates (required)**
The previous codebase has not been modified (with the exception of ```README```, ```.gitignore``` and ```package.json```. Other than the dapptools dependencies described above, the ```UnbondingLockTest``` solidity test had been added under ```src/test``` (new directory under which all foundry-related tests should be added).

**How did you test each of these updates (required)**
Run the previous tests individually and run the pre-existing tests.


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] All tests using `yarn test` pass
