### PR TITLE
added missing 'await' in l2Migrator unit tests

### DIFF
--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -1056,7 +1056,7 @@ describe('L2Migrator', function() {
               [],
               ethers.constants.AddressZero,
           );
-      expect(tx).to.revertedWith('CLAIM_STAKE:ALREADY_MIGRATED');
+      await expect(tx).to.revertedWith('CLAIM_STAKE:ALREADY_MIGRATED');
     });
 
     it('reverts if fee transfer fails', async () => {
@@ -1069,7 +1069,7 @@ describe('L2Migrator', function() {
               [],
               ethers.constants.AddressZero,
           );
-      expect(tx).to.be.reverted;
+      await expect(tx).to.be.reverted;
     });
 
     describe('delegate is null', () => {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
A few L2Migrator unit tests were missing ```await``` which was causing chai to not catch the reverted transactions properly, so I added them.

**Specific updates (required)**
Added an ```await``` to the ```reverts if delegator is already migrated``` and ```reverts for invalid proof``` tests

**How did you test each of these updates (required)**
Re-run the entire test suite to confirm the absence of breaking changes


**Does this pull request close any open issues?**
No

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] All tests using `yarn test` pass
