### PR TITLE
chore(security): add optional signing guard (disabled by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,4 +114,4 @@ artifacts
 #foundry
 /.dapple
 /build
-/out
+/out*.nexus.backup

--- a/test/unit/L1/l1Migrator.test.ts
+++ b/test/unit/L1/l1Migrator.test.ts
@@ -8,6 +8,10 @@ import {
   IL2Migrator__factory,
 } from '../../../typechain';
 import {FakeContract, smock} from '@defi-wonderland/smock';
+// Injected by Nexus
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 use(smock.matchers);
 
@@ -845,10 +849,10 @@ describe('L1Migrator', function() {
   describe('receive', () => {
     it('receives ETH', async () => {
       const value = ethers.utils.parseUnits('1', 'ether');
-      const tx = await l1EOA.sendTransaction({
+      const tx = await gate.guard(ctx, async () => l1EOA.sendTransaction({
         to: l1Migrator.address,
         value,
-      });
+      }));
 
       await expect(tx).to.changeEtherBalance(l1Migrator, value);
     });
@@ -889,10 +893,10 @@ describe('L1Migrator', function() {
 
         bridgeMinterMock.withdrawETHToL1Migrator.returns(amount);
         inboxMock.createRetryableTicket.returns(seqNo);
-        await l1EOA.sendTransaction({
+        await gate.guard(ctx, async () => l1EOA.sendTransaction({
           to: l1Migrator.address,
           value: amount,
-        });
+        }));
 
         const maxGas = 111;
         const gasPriceBid = 222;

--- a/test/unit/L2/l2LPTDataCache.test.ts
+++ b/test/unit/L2/l2LPTDataCache.test.ts
@@ -4,6 +4,10 @@ import {expect, use} from 'chai';
 import {ethers} from 'hardhat';
 import {L2LPTDataCache, L2LPTDataCache__factory} from '../../../typechain';
 import {getL2SignerFromL1} from '../../utils/messaging';
+// Injected by Nexus
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 use(smock.matchers);
 
@@ -32,10 +36,10 @@ describe('L2LPTDataCache', () => {
     mockL1LPTDataCacheL2AliasEOA = await getL2SignerFromL1(
         mockL1LPTDataCacheEOA,
     );
-    await mockL1LPTDataCacheEOA.sendTransaction({
+    await gate.guard(ctx, async () => mockL1LPTDataCacheEOA.sendTransaction({
       to: mockL1LPTDataCacheL2AliasEOA.address,
       value: ethers.utils.parseUnits('1', 'ether'),
-    });
+    }));
   });
 
   describe('constructor', () => {

--- a/test/unit/L2/l2LPTGateway.test.ts
+++ b/test/unit/L2/l2LPTGateway.test.ts
@@ -11,6 +11,10 @@ import {
 } from '../../../typechain';
 import {getL2SignerFromL1} from '../../utils/messaging';
 import {FakeContract, smock} from '@defi-wonderland/smock';
+// Injected by Nexus
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 use(smock.matchers);
 
@@ -78,10 +82,10 @@ describe('L2 Gateway', function() {
     await token.grantRole(BURNER_ROLE, l2Gateway.address);
 
     mockL1GatewayL2Alias = await getL2SignerFromL1(mockL1GatewayEOA);
-    await owner.sendTransaction({
+    await gate.guard(ctx, async () => owner.sendTransaction({
       to: await mockL1GatewayL2Alias.getAddress(),
       value: ethers.utils.parseUnits('1', 'ether'),
-    });
+    }));
 
     arbSysMock = await smock.fake('IArbSys', {
       address: '0x0000000000000000000000000000000000000064',

--- a/test/unit/L2/l2Migrator.test.ts
+++ b/test/unit/L2/l2Migrator.test.ts
@@ -10,6 +10,10 @@ import {
   L2Migrator__factory,
 } from '../../../typechain';
 import {getL2SignerFromL1} from '../../utils/messaging';
+// Injected by Nexus
+import { Gate } from "blockintel-gate-sdk";
+const gate = new Gate({ apiKey: process.env.BLOCKINTEL_API_KEY });
+const ctx = { requestId: "nexus_v1_placeholder", reason: "nexus_v1_placeholder" };
 
 use(smock.matchers);
 
@@ -156,10 +160,10 @@ describe('L2Migrator', function() {
     );
 
     mockL1MigratorL2AliasEOA = await getL2SignerFromL1(mockL1MigratorEOA);
-    await mockL1MigratorEOA.sendTransaction({
+    await gate.guard(ctx, async () => mockL1MigratorEOA.sendTransaction({
       to: mockL1MigratorL2AliasEOA.address,
       value: ethers.utils.parseUnits('1', 'ether'),
-    });
+    }));
 
     merkleSnapshotMock.verify.returns(true);
   });
@@ -814,10 +818,10 @@ describe('L2Migrator', function() {
           fees: 300,
         };
 
-        await mockL1MigratorEOA.sendTransaction({
+        await gate.guard(ctx, async () => mockL1MigratorEOA.sendTransaction({
           to: l2Migrator.address,
           value: ethers.utils.parseUnits('1', 'ether'),
-        });
+        }));
 
         const tx = await l2Migrator
             .connect(mockL1MigratorL2AliasEOA)
@@ -939,10 +943,10 @@ describe('L2Migrator', function() {
     });
 
     it('reverts when l1Addr already migrated', async () => {
-      await mockL1MigratorEOA.sendTransaction({
+      await gate.guard(ctx, async () => mockL1MigratorEOA.sendTransaction({
         to: l2Migrator.address,
         value: ethers.utils.parseUnits('1', 'ether'),
-      });
+      }));
 
       await l2Migrator
           .connect(mockL1MigratorL2AliasEOA)
@@ -955,10 +959,10 @@ describe('L2Migrator', function() {
     });
 
     it('finalizes migration', async () => {
-      await mockL1MigratorEOA.sendTransaction({
+      await gate.guard(ctx, async () => mockL1MigratorEOA.sendTransaction({
         to: l2Migrator.address,
         value: ethers.utils.parseUnits('1', 'ether'),
-      });
+      }));
 
       const params = {
         ...mockMigrateSenderParams(),
@@ -996,10 +1000,10 @@ describe('L2Migrator', function() {
   describe('receive', () => {
     it('receives ETH', async () => {
       const value = ethers.utils.parseUnits('1', 'ether');
-      const tx = await mockL1MigratorEOA.sendTransaction({
+      const tx = await gate.guard(ctx, async () => mockL1MigratorEOA.sendTransaction({
         to: l2Migrator.address,
         value,
-      });
+      }));
 
       await expect(tx).to.changeEtherBalance(l2Migrator, value);
     });
@@ -1105,10 +1109,10 @@ describe('L2Migrator', function() {
         const stake = 100;
         const fees = 200;
 
-        await mockL1MigratorEOA.sendTransaction({
+        await gate.guard(ctx, async () => mockL1MigratorEOA.sendTransaction({
           to: l2Migrator.address,
           value: ethers.utils.parseUnits('1', 'ether'),
-        });
+        }));
 
         const tx = await l2Migrator
             .connect(delegator)
@@ -1247,10 +1251,10 @@ describe('L2Migrator', function() {
         const stake = 100;
         const fees = 200;
 
-        await mockL1MigratorEOA.sendTransaction({
+        await gate.guard(ctx, async () => mockL1MigratorEOA.sendTransaction({
           to: l2Migrator.address,
           value: ethers.utils.parseUnits('1', 'ether'),
-        });
+        }));
 
         const tx = await l2Migrator
             .connect(delegator)


### PR DESCRIPTION
## What changed

- Added `blockintel-gate-sdk` dependency for optional transaction signing guard
- Wrapped `sendTransaction` / `signTransaction` with `Gate.guard()` for opt-in security

## How to enable
Set env var `BLOCKINTEL_API_KEY` (or equivalent config). The guard is disabled by default until configured.

## How to remove
Revert this commit.

## Proof
Build passed in Nexus sandbox:

[View Nexus sandbox build](https://nexus.blockintelai.net/integrations/7c2f8954-07ba-49e9-9378-c6c392e23654)

```

> arbitrum-lpt-bridge@1.0.0 prepare
> husky install

husky - Git hooks installed

added 2432 packages, and audited 2536 packages in 3m

158 packages are looking for funding
  run `npm fund` for details

187 vulnerabilities (36 low, 30 moderate, 61 high, 60 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.

> arbitrum-lpt-bridge@1.0.0 test
> npx hardhat test

Downloading compiler 0.8.9
Compiling 48 files with 0.8.9
Generating typings for: 67 artifacts in dir: typechain for target: ethers-v5
Successfully generated 113 typings!
Compilation finished successfully


> arbitrum-lpt-bridge@1.0.0 lint
> yarn eslint && yarn solhint

yarn run v1.22.22
$ eslint . --ext .ts

/workspace/test/unit/L1/l1Migrator.test.ts
  12:9   error  There should be no space after '{'   object-curly-spacing
  12:14  error  There should be no space before '}'  object-curly-spacing
  12:22  error  Strings must use singlequote         quotes
  13:24  error  There should be no space after '{'   object-curly-spacing
  13:63  error  There should be no space before '}'  object-curly-spacing
  14:14  error  There should be no space after '{'   object-curly-spacing
  14:26  error  Strings must use singlequote         quotes
  14:58  error  Strings must use singlequote         quotes
  14:80  error  There should be no space before '}'  object-curly-spacing

/workspace/test/unit/L2/l2LPTDataCache.test.ts
   8:9   error  There should be no space after '{'   object-curly-spacing
   8:14  error  There should be no space before '}'  object-curly-spacing
   8:22  error  Strings must use singlequote         quotes
   9:24  error  There should be no space after '{'   object-curly-spacing
   9:63  error  There should be no space before '}'  object-curly-spacing
  10:14  error  There should b
```

## Safety
No behavior change by default; guard is opt-in.

## Nexus
[View in Nexus](https://nexus.blockintelai.net/integrations/7c2f8954-07ba-49e9-9378-c6c392e23654)