### PR TITLE
docs: clarify _newDelegate branch behavior in claimStake

### DIFF
--- a/contracts/L2/gateway/L2Migrator.sol
+++ b/contracts/L2/gateway/L2Migrator.sol
@@ -255,7 +255,7 @@ contract L2Migrator is ManagerProxyTarget, L2ArbitrumMessenger, IMigrator {
      * @param _stake Stake of delegator on L1
      * @param _fees Fees of delegator on L1
      * @param _proof Merkle proof of inclusion in Merkle tree state snapshot
-     * @param _newDelegate Optional address of a new delegate on L2
+     * @param _newDelegate Optional address of a new delegate on L2. Only applied when `_delegate` is non-zero and has no `DelegatorPool`; ignored otherwise.
      */
     function claimStake(
         address _delegate,


### PR DESCRIPTION
Clarifies NatSpec for `L2Migrator.claimStake`: `_newDelegate` is only applied when `_delegate` is non-zero and has no `DelegatorPool`; it is ignored otherwise. Documents existing behavior, no logic change.